### PR TITLE
 Memory Attentionのtflite対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,18 +79,18 @@ You can also download it from the following.
 - https://storage.googleapis.com/ailia-models/segment-anything-2/prompt_encoder_hiera_t.onnx
 - https://storage.googleapis.com/ailia-models/segment-anything-2/mask_decoder_hiera_t.onnx
 - https://storage.googleapis.com/ailia-models/segment-anything-2/memory_encoder_hiera_t.onnx
-- https://storage.googleapis.com/ailia-models/segment-anything-2/memory_attention_hiera_t.onnx
 - https://storage.googleapis.com/ailia-models/segment-anything-2/mlp_hiera_t.onnx
-
-In addition, it is planned to update to use a 6-dimensional MatMul in MemoryAttention in the future.
+- https://storage.googleapis.com/ailia-models/segment-anything-2/memory_attention_hiera_t.onnx (6dim matmul, batch = N)
+- https://storage.googleapis.com/ailia-models/segment-anything-2/memory_attention_hiera_t.opt.onnx (4dim matmul, batch = 1)
 
 ### TFLITE
 
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2/image_encoder_hiera_t.tflite
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2/prompt_encoder_hiera_t.tflite
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2/mask_decoder_hiera_t.tflite
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2/mlp_hiera_t.tflite
-- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2/memory_attention_hiera_t.tflite
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2/memory_encoder_hiera_t.tflite
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2/memory_attention_hiera_t.tflite (4dim matmul, batch = 1, num_maskmem = 1)
 
 The memory attention in tflite does not support dynamic shapes, so num_maskmem and max_obj_ptrs_in_encoder need to be fixed to 1.
 

--- a/export_video_predictor.py
+++ b/export_video_predictor.py
@@ -48,7 +48,10 @@ print(f"using device: {device}")
 
 from sam2.build_sam import build_sam2_video_predictor
 
-predictor = build_sam2_video_predictor(model_cfg, sam2_checkpoint, device=device)
+if export_to_tflite or import_from_tflite:
+    predictor = build_sam2_video_predictor(model_cfg, sam2_checkpoint, device=device, num_maskmem=1, max_obj_ptrs_in_encoder=1)
+else:
+    predictor = build_sam2_video_predictor(model_cfg, sam2_checkpoint, device=device)
 
 
 def show_mask(mask, ax, obj_id=None, random_color=False):

--- a/export_video_predictor.py
+++ b/export_video_predictor.py
@@ -48,11 +48,10 @@ print(f"using device: {device}")
 
 from sam2.build_sam import build_sam2_video_predictor
 
-if export_to_tflite or import_from_tflite:
-    predictor = build_sam2_video_predictor(model_cfg, sam2_checkpoint, device=device, num_maskmem=1, max_obj_ptrs_in_encoder=1)
-else:
-    predictor = build_sam2_video_predictor(model_cfg, sam2_checkpoint, device=device)
+predictor = build_sam2_video_predictor(model_cfg, sam2_checkpoint, device=device)
 
+if export_to_tflite or import_from_tflite:
+    predictor.set_num_maskmem(num_maskmem=1, max_obj_ptrs_in_encoder=1)
 
 def show_mask(mask, ax, obj_id=None, random_color=False):
     if random_color:

--- a/sam2/modeling/memory_attention.py
+++ b/sam2/modeling/memory_attention.py
@@ -59,23 +59,19 @@ class MemoryAttentionLayer(nn.Module):
         # Self-Attention
         tgt2 = self.norm1(tgt)
         q = k = tgt2 + query_pos if self.pos_enc_at_attn else tgt2
-        tgt2 = self.self_attn(q, k, v=tgt2, num_k_exclude_rope=torch.tensor(0))
+        tgt2 = self.self_attn.self_attn(q, k = k, v = tgt2)
         tgt = tgt + self.dropout1(tgt2)
         return tgt
 
-    def _forward_ca(self, tgt, memory, query_pos, pos, num_k_exclude_rope=torch.tensor(0)):
-        kwds = {}
-        if num_k_exclude_rope.item() > 0:
-            assert isinstance(self.cross_attn_image, RoPEAttention)
-            kwds = {"num_k_exclude_rope": num_k_exclude_rope}
-
+    def _forward_ca(self, tgt, memory_1, memory_2, query_pos, pos_1, pos_2):
         # Cross-Attention
         tgt2 = self.norm2(tgt)
-        tgt2 = self.cross_attn_image(
+        tgt2 = self.cross_attn_image.cross_attn(
             q=tgt2 + query_pos if self.pos_enc_at_cross_attn_queries else tgt2,
-            k=memory + pos if self.pos_enc_at_cross_attn_keys else memory,
-            v=memory,
-            **kwds,
+            k_1=memory_1 + pos_1 if self.pos_enc_at_cross_attn_keys else memory_1,
+            v_1=memory_1,
+            k_2=memory_2 + pos_2 if self.pos_enc_at_cross_attn_keys else memory_2,
+            v_2=memory_2
         )
         tgt = tgt + self.dropout2(tgt2)
         return tgt
@@ -83,15 +79,16 @@ class MemoryAttentionLayer(nn.Module):
     def forward(
         self,
         tgt,
-        memory,
-        pos: Optional[Tensor] = None,
+        memory_1,
+        memory_2,
+        pos_1: Optional[Tensor] = None,
+        pos_2: Optional[Tensor] = None,
         query_pos: Optional[Tensor] = None,
-        num_k_exclude_rope: int = 0,
     ) -> torch.Tensor:
 
         # Self-Attn, Cross-Attn
         tgt = self._forward_sa(tgt, query_pos)
-        tgt = self._forward_ca(tgt, memory, query_pos, pos, num_k_exclude_rope)
+        tgt = self._forward_ca(tgt, memory_1, memory_2, query_pos, pos_1, pos_2)
         # MLP
         tgt2 = self.norm3(tgt)
         tgt2 = self.linear2(self.dropout(self.activation(self.linear1(tgt2))))
@@ -144,10 +141,11 @@ class MemoryAttention(nn.Module):
     def forward(
         self,
         curr: torch.Tensor,  # self-attention inputs
-        memory: torch.Tensor,  # cross-attention inputs
+        memory_1: torch.Tensor,  # cross-attention inputs
+        memory_2: torch.Tensor,  # cross-attention inputs
         curr_pos: Optional[Tensor] = None,  # pos_enc for self-attention inputs
-        memory_pos: Optional[Tensor] = None,  # pos_enc for cross-attention inputs
-        num_obj_ptr_tokens: int = 0,  # number of object pointer *tokens*
+        memory_pos_1: Optional[Tensor] = None,  # pos_enc for cross-attention inputs
+        memory_pos_2: Optional[Tensor] = None,  # pos_enc for cross-attention inputs
     ):
         if isinstance(curr, list):
             assert isinstance(curr_pos, list)
@@ -158,7 +156,7 @@ class MemoryAttention(nn.Module):
             )
 
         assert (
-            curr.shape[1] == memory.shape[1]
+            curr.shape[1] == memory_1.shape[1]
         ), "Batch size must be the same for curr and memory"
 
         output = curr
@@ -169,20 +167,18 @@ class MemoryAttention(nn.Module):
             # Convert to batch first
             output = output.transpose(0, 1)
             curr_pos = curr_pos.transpose(0, 1)
-            memory = memory.transpose(0, 1)
-            memory_pos = memory_pos.transpose(0, 1)
+            memory_1 = memory_1.transpose(0, 1)
+            memory_2 = memory_2.transpose(0, 1)
+            memory_pos_1 = memory_pos_1.transpose(0, 1)
+            memory_pos_2 = memory_pos_2.transpose(0, 1)
 
         for layer in self.layers:
-            kwds = {}
-            if isinstance(layer.cross_attn_image, RoPEAttention):
-                kwds = {"num_k_exclude_rope": num_obj_ptr_tokens}
-
             output = layer(
                 tgt=output,
-                memory=memory,
-                pos=memory_pos,
-                query_pos=curr_pos,
-                **kwds,
+                memory_1=memory_1,
+                memory_2=memory_2,
+                pos_1=memory_pos_1,
+                pos_2=memory_pos_2,
             )
         normed_output = self.norm(output)
 

--- a/sam2/modeling/position_encoding.py
+++ b/sam2/modeling/position_encoding.py
@@ -253,13 +253,13 @@ def apply_rotary_matenc(xq, xk, rotmats, repeat_freqs_k=False):
     # tfliteでは4次元テンソルまでしか扱えないのでバッチサイズに制約をかける
 
     bq, hq, nq, cq = xq.shape
-    torch._check_is_size(bq)
-    torch._check_is_size(hq)
-    torch._check_is_size(nq)
-    torch._check_is_size(cq)
-    torch._check(bq == 1) # for dynamo trace
-    torch._check(hq == 1) # for dynamo trace
-    torch._check(cq == 256) # for dynamo trace
+    #torch._check_is_size(bq)
+    #torch._check_is_size(hq)
+    #torch._check_is_size(nq)
+    #torch._check_is_size(cq)
+    #torch._check(bq == 1) # for dynamo trace
+    #torch._check(hq == 1) # for dynamo trace
+    #torch._check(cq == 256) # for dynamo trace
 
     #print(rotmats.shape)
 
@@ -271,9 +271,9 @@ def apply_rotary_matenc(xq, xk, rotmats, repeat_freqs_k=False):
     k_rotmat = q_rotmat.repeat(nk // nq, 1, 1, 1)# if repeat_freqs_k else rotmats # for tflite trace, repeat_freqs_k == Falseの場合は nk // nq == 1 なのでrepeatを常に呼び出しても等価になる
 
     bk, hk, nk, ck = xk.shape
-    torch._check_is_size(bq == 1)
-    torch._check_is_size(hq == 1)
-    torch._check(ck == 256)
+    #torch._check_is_size(bq == 1)
+    #torch._check_is_size(hq == 1)
+    #torch._check(ck == 256)
 
     #torch._check(xk.size(3) == 256)
     

--- a/sam2/modeling/position_encoding.py
+++ b/sam2/modeling/position_encoding.py
@@ -277,9 +277,9 @@ def apply_rotary_matenc(xq, xk, rotmats, repeat_freqs_k=False):
 
     #torch._check(xk.size(3) == 256)
     
-    k_in = xk.reshape(nk, ck//2, 2, 1)
-    k_in = k_in[:k_rotmat.shape[0], :, :, :]
-    k_out = torch.matmul(k_rotmat, k_in).reshape(1, 1, nk // nq * 4096, 256)
+    k_in = xk.reshape(nk, 128, 2, 1)
+    #k_in = k_in[:k_rotmat.shape[0], :, :, :]
+    k_out = torch.matmul(k_rotmat, k_in).reshape(1, 1, nk, 256)
 
     #print("k_rotmat", k_rotmat.shape)
     #print("k_in", k_in.shape)

--- a/sam2/modeling/position_encoding.py
+++ b/sam2/modeling/position_encoding.py
@@ -268,7 +268,7 @@ def apply_rotary_matenc(xq, xk, rotmats, repeat_freqs_k=False):
     #print(q_out.shape)
 
     bk, hk, nk, ck = xk.shape
-    k_rotmat = q_rotmat.repeat(nk // nq, 1, 1, 1)# if repeat_freqs_k else rotmats # for tflite trace, repeat_freqs_k == Falseの場合は nk // nq == 1 なのでrepeatを常に呼び出しても等価になる
+    k_rotmat = q_rotmat.repeat(nk // 4096, 1, 1, 1)# if repeat_freqs_k else rotmats # for tflite trace, repeat_freqs_k == Falseの場合は nk // nq == 1 なのでrepeatを常に呼び出しても等価になる
 
     bk, hk, nk, ck = xk.shape
     #torch._check_is_size(bq == 1)

--- a/sam2/modeling/sam/transformer.py
+++ b/sam2/modeling/sam/transformer.py
@@ -344,17 +344,17 @@ class RoPEAttention(Attention):
         v = self._separate_heads(v, self.num_heads)
 
         # Apply rotary position encoding
-        if USE_MAT_ROTARY_ENC:
-            #self.rotmats = self.rotmats.to(q.device)
-            if self.rotmats.shape[2] != q.shape[-2]:
-                raise("rotmat shape error " + str(self.rotmats.shape[2]) + " " + str(q.shape[-2]))
-        else:
-            #self.freqs_cis = self.freqs_cis.to(q.device)
-            if self.freqs_cis.shape[0] != q.shape[-2]:
-                raise("freqs_cis shape error " + str(self.freqs_cis.shape[0]) + " " + str(q.shape[-2]))
+        #if USE_MAT_ROTARY_ENC:
+        #    #self.rotmats = self.rotmats.to(q.device)
+        #    if self.rotmats.shape[2] != q.shape[-2]:
+        #        raise("rotmat shape error " + str(self.rotmats.shape[2]) + " " + str(q.shape[-2]))
+        #else:
+        #    #self.freqs_cis = self.freqs_cis.to(q.device)
+        #    if self.freqs_cis.shape[0] != q.shape[-2]:
+        #        raise("freqs_cis shape error " + str(self.freqs_cis.shape[0]) + " " + str(q.shape[-2]))
 
-        if q.shape[-2] != k.shape[-2]:
-            assert self.rope_k_repeat
+        #if q.shape[-2] != k.shape[-2]:
+        #    assert self.rope_k_repeat
 
         if USE_MAT_ROTARY_ENC:
             q, k = apply_rotary_matenc(
@@ -412,17 +412,17 @@ class RoPEAttention(Attention):
         v_2 = self._separate_heads(v_2, self.num_heads)
 
         # Apply rotary position encoding
-        if USE_MAT_ROTARY_ENC:
-            #self.rotmats = self.rotmats.to(q.device)
-            if self.rotmats.shape[2] != q.shape[-2]:
-                raise("rotmat shape error " + str(self.rotmats.shape[2]) + " " + str(q.shape[-2]))
-        else:
-            #self.freqs_cis = self.freqs_cis.to(q.device)
-            if self.freqs_cis.shape[0] != q.shape[-2]:
-                raise("freqs_cis shape error " + str(self.freqs_cis.shape[0]) + " " + str(q.shape[-2]))
+        #if USE_MAT_ROTARY_ENC:
+        #    #self.rotmats = self.rotmats.to(q.device)
+        #    if self.rotmats.shape[2] != q.shape[-2]:
+        #        raise("rotmat shape error " + str(self.rotmats.shape[2]) + " " + str(q.shape[-2]))
+        #else:
+        #    #self.freqs_cis = self.freqs_cis.to(q.device)
+        #    if self.freqs_cis.shape[0] != q.shape[-2]:
+        #        raise("freqs_cis shape error " + str(self.freqs_cis.shape[0]) + " " + str(q.shape[-2]))
 
-        if q.shape[-2] != k_1.shape[-2]:
-            assert self.rope_k_repeat
+        #if q.shape[-2] != k_1.shape[-2]:
+        #    assert self.rope_k_repeat
 
         if USE_MAT_ROTARY_ENC:
             q, k_1 = apply_rotary_matenc(

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -207,7 +207,7 @@ class SAM2Base(torch.nn.Module):
         assert(self.image_size == 1024)
         assert(self.num_feature_levels == 3)
         assert(self.hidden_dim == 256)
-        assert(self.num_maskmem == 1 or self.num_maskmem == 7)
+        assert(self.num_maskmem == 7)
         assert(self.directly_add_no_mem_embed == True)
         #assert(self.training == False)
         assert(self.mem_dim == 64)
@@ -235,10 +235,16 @@ class SAM2Base(torch.nn.Module):
         assert(self.sam_mask_decoder.dynamic_multimask_stability_thresh == 0.98)
         assert(self.max_cond_frames_in_attn == -1)
         assert(self.memory_temporal_stride_for_eval == 1)
-        assert(self.max_obj_ptrs_in_encoder == 1 or self.max_obj_ptrs_in_encoder == 16)
+        assert(self.max_obj_ptrs_in_encoder == 16)
         assert(self.only_obj_ptrs_in_the_past_for_eval == True)
         assert(self.multimask_output_for_tracking == True)
         assert(self.use_multimask_token_for_obj_ptr == True)
+
+    def set_num_maskmem(self, num_maskmem, max_obj_ptrs_in_encoder):
+        self.num_maskmem = num_maskmem
+        self.max_obj_ptrs_in_encoder = max_obj_ptrs_in_encoder
+        assert(self.num_maskmem == 1 or self.num_maskmem == 7)
+        assert(self.max_obj_ptrs_in_encoder == 1 or self.max_obj_ptrs_in_encoder == 16)
 
     @property
     def device(self):

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -918,7 +918,7 @@ class SAM2Base(torch.nn.Module):
             #print("memory_pos_embed", memory_pos_embed.shape, memory_pos_embed.dtype)
             #print("num_obj_ptr_tokens", num_obj_ptr_tokens)
             torch.onnx.export(
-                self.memory_attention, (current_vision_feats[0], memory_1, memory_2, current_vision_pos_embeds[0], memory_pos_embed_1, memory_pos_embed_2), 'model/memory_attention_'+model_id+'.onnx',
+                self.memory_attention, (current_vision_feats[0], memory_1, memory_2, current_vision_pos_embeds[0], memory_pos_embed_1, memory_pos_embed_2), 'model/memory_attention_'+model_id+'.opt.onnx',
                 input_names=["curr", "memory_1", "memory_2", "curr_pos", "memory_pos_1", "memory_pos_2"],
                 output_names=["pix_feat"],
                 dynamic_axes={
@@ -939,7 +939,7 @@ class SAM2Base(torch.nn.Module):
             print("begin memory attention onnx")
             import onnxruntime
             if self.memory_attention_onnx == None:
-                self.memory_attention_onnx = onnxruntime.InferenceSession("model/memory_attention_"+model_id+".onnx")
+                self.memory_attention_onnx = onnxruntime.InferenceSession("model/memory_attention_"+model_id+".opt.onnx")
             import numpy as np
             #num_obj_ptr_tokens_numpy = np.array((num_obj_ptr_tokens)).astype(np.int64)
             #print("curr", np.sum(current_vision_feats[0].numpy()))

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -915,13 +915,18 @@ class SAM2Base(torch.nn.Module):
                 input_names=["curr", "memory_1", "memory_2", "curr_pos", "memory_pos_1", "memory_pos_2"],
                 output_names=["pix_feat"],
                 dynamic_axes={
-                    'memory_1': {1: 'n'},
-                    'memory_2': {1: 'n'},
-                    'memory_pos_1': {1: 'n'},
-                    'memory_pos_2': {1: 'n'}
+                    'memory_1': {0: 'n_1'},
+                    'memory_2': {0: 'n_2'},
+                    'memory_pos_1': {0: 'n_1'},
+                    'memory_pos_2': {0: 'n_2'}
                 },
                 verbose=False, opset_version=17
             )
+            #export_options = torch.onnx.ExportOptions(dynamic_shapes=True)
+            #onnx_program  =torch.onnx.dynamo_export(
+            #    self.memory_attention, current_vision_feats[0], memory_1, memory_2, current_vision_pos_embeds[0], memory_pos_embed_1, memory_pos_embed_2, export_options=export_options
+            #)
+            #onnx_program.save('model/memory_attention_'+model_id+'.onnx')
 
         if import_from_onnx:
             print("begin memory attention onnx")


### PR DESCRIPTION
- tfliteの場合、DynamicShapeがうまく扱えないため、num_maskmem=1に固定してtflite出力する
- RotaryEncoderにおいて、デフォルトだと6次元のMatMulが発生するため、バッチサイズを1に固定して4次元のMatMulに変換する
- memoryをmaskmem (memory1) とobjptr (memory2)に分解することで、動的なShape計算を抑制し、ONNXのDynamicShapeの適用を容易にする
- onnxでbatch=1に固定する場合はモデル名をoptにする