### PR TITLE
Fix reference mismatch

### DIFF
--- a/sam2/modeling/sam/prompt_encoder.py
+++ b/sam2/modeling/sam/prompt_encoder.py
@@ -113,9 +113,12 @@ class PromptEncoder(nn.Module):
         table[2] = self.point_embeddings[1].weight
         table[3] = self.point_embeddings[2].weight
         table[4] = self.point_embeddings[3].weight
-        for i in range(labels.shape[0]):
-            point_embedding[i] = point_embedding[i] + table[labels[i] + 1]
-
+        for b in range(labels.shape[0]):
+            for i in range(labels.shape[1]):
+                if labels[b][i] == -1:
+                    point_embedding[b][i] = table[labels[b][i] + 1]
+                else:
+                    point_embedding[b][i] = point_embedding[b][i] + table[labels[b][i] + 1]
         return point_embedding
 
     def _embed_boxes(self, boxes: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
torchで実行した場合に、baseブランチと、exportブランチで推論結果に差異がある問題を修正するPRです。

不具合の修正
- position embeddingが間違っておりsparse embeddingの値が正しくない問題を修正
（対応してtfliteのprompt encoderのモデルの更新が必要）

微小誤差に関する補足
- memory_attentionにおいて、flash attentionの有無で微小誤差が出る
- USE_MAT_ROTARY_ENCをTrueにした場合にcomplexを要素2のベクトルの演算に置き換えているため、微小誤差が出る