### PR TITLE
SAM2.1 FULLY_INTEGER_QUANTIZATION

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ tflite (int8)
 
 ```
 export PJRT_DEVICE=CPU
+python3 export_image_predictor.py --accuracy int8 --image_size 512 --mode calibration
+python3 export_video_predictor.py --accuracy int8 --image_size 512 --mode calibration
 python3 export_image_predictor.py --framework tflite --accuracy int8 --image_size 512
 python3 export_video_predictor.py --framework tflite --accuracy int8 --image_size 512
 ```

--- a/README.md
+++ b/README.md
@@ -43,14 +43,36 @@ python3 export_image_predictor.py --framework tflite
 python3 export_video_predictor.py --framework tflite
 ```
 
-tflite (int8)
+generate calibration data
 
 ```
 export PJRT_DEVICE=CPU
 python3 export_image_predictor.py --accuracy int8 --image_size 512 --mode calibration
 python3 export_video_predictor.py --accuracy int8 --image_size 512 --mode calibration
+```
+
+tflite (int8)
+
+```
+export PJRT_DEVICE=CPU
 python3 export_image_predictor.py --framework tflite --accuracy int8 --image_size 512
 python3 export_video_predictor.py --framework tflite --accuracy int8 --image_size 512
+```
+
+tflite (mixed)
+
+```
+export PJRT_DEVICE=CPU
+export AIEDGETORCH_LAYOUT_OPTIMIZE_PARTITIONER=MINCUT
+python3 export_image_predictor.py --framework tflite --accuracy mixed --image_size 512
+export AIEDGETORCH_LAYOUT_OPTIMIZE_PARTITIONER=GREEDY
+python3 export_video_predictor.py --framework tflite --accuracy mixed --image_size 512
+```
+
+export AIEDGETORCH_LAYOUT_OPTIMIZE_PARTITIONER=GREEDY requires for below error of memory encoder.
+
+```
+AttributeError: 'OptimizeLayoutTransposesPass' object has no attribute 'get_paired_q_dq_ops'
 ```
 
 ## Inference only
@@ -77,6 +99,14 @@ tflite (int8)
 download_tflite_models.sh
 python3 export_image_predictor.py --framework tflite --mode import --accuracy int8 --image_size 512
 python3 export_video_predictor.py --framework tflite --mode import --accuracy int8 --image_size 512
+```
+
+tflite (mixed)
+
+```
+download_tflite_models.sh
+python3 export_image_predictor.py --framework tflite --mode import --accuracy mixed --image_size 512
+python3 export_video_predictor.py --framework tflite --mode import --accuracy mixed --image_size 512
 ```
 
 ailia_tflite
@@ -133,7 +163,7 @@ You can also download it from the following.
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_attention_hiera_t_2.1.tflite (4dim matmul, batch = 1, num_maskmem = 8)
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/obj_ptr_tpos_proj_hiera_t_2.1.tflite
 
-#### Int8
+#### Int8 (tensorflow quantization)
 
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/image_encoder_hiera_t_2.1_512.int8.tflite
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/prompt_encoder_hiera_t_2.1_512.int8.tflite
@@ -142,6 +172,16 @@ You can also download it from the following.
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_encoder_hiera_t_2.1_512.int8.tflite
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_attention_hiera_t_2.1_512.int8.tflite (4dim matmul, batch = 1, num_maskmem = 8)
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/obj_ptr_tpos_proj_hiera_t_2.1_512.int8.tflite
+
+#### Mixed (torch quantization)
+
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/image_encoder_hiera_t_2.1_512.mixed.tflite
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/prompt_encoder_hiera_t_2.1_512.mixed.tflite
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/mask_decoder_hiera_t_2.1_512.mixed.tflite
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/mlp_hiera_t_2.1_512.mixed.tflite
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_encoder_hiera_t_2.1_512.mixed.tflite
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_attention_hiera_t_2.1_512.mixed.tflite (4dim matmul, batch = 1, num_maskmem = 8)
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/obj_ptr_tpos_proj_hiera_t_2.1_512.mixed.tflite
 
 ## Inference Example
 

--- a/README.md
+++ b/README.md
@@ -63,16 +63,8 @@ tflite (mixed)
 
 ```
 export PJRT_DEVICE=CPU
-export AIEDGETORCH_LAYOUT_OPTIMIZE_PARTITIONER=MINCUT
 python3 export_image_predictor.py --framework tflite --accuracy mixed --image_size 512
-export AIEDGETORCH_LAYOUT_OPTIMIZE_PARTITIONER=GREEDY
 python3 export_video_predictor.py --framework tflite --accuracy mixed --image_size 512
-```
-
-export AIEDGETORCH_LAYOUT_OPTIMIZE_PARTITIONER=GREEDY requires for below error of memory encoder.
-
-```
-AttributeError: 'OptimizeLayoutTransposesPass' object has no attribute 'get_paired_q_dq_ops'
 ```
 
 ## Inference only

--- a/README.md
+++ b/README.md
@@ -176,12 +176,8 @@ You can also download it from the following.
 #### Mixed (torch quantization)
 
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/image_encoder_hiera_t_2.1_512.mixed.tflite
-- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/prompt_encoder_hiera_t_2.1_512.mixed.tflite
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/mask_decoder_hiera_t_2.1_512.mixed.tflite
-- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/mlp_hiera_t_2.1_512.mixed.tflite
-- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_encoder_hiera_t_2.1_512.mixed.tflite
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_attention_hiera_t_2.1_512.mixed.tflite (4dim matmul, batch = 1, num_maskmem = 8)
-- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/obj_ptr_tpos_proj_hiera_t_2.1_512.mixed.tflite
 
 ## Inference Example
 

--- a/README.md
+++ b/README.md
@@ -35,12 +35,20 @@ python3 export_image_predictor.py --framework onnx
 python3 export_video_predictor.py --framework onnx
 ```
 
-tflite
+tflite (float)
 
 ```
 export PJRT_DEVICE=CPU
 python3 export_image_predictor.py --framework tflite
 python3 export_video_predictor.py --framework tflite
+```
+
+tflite (int8)
+
+```
+export PJRT_DEVICE=CPU
+python3 export_image_predictor.py --framework tflite --accuracy int8 --image_size 512
+python3 export_video_predictor.py --framework tflite --accuracy int8 --image_size 512
 ```
 
 ## Inference only
@@ -53,12 +61,20 @@ python3 export_image_predictor.py --framework onnx --mode import
 python3 export_video_predictor.py --framework onnx --mode import
 ```
 
-tflite
+tflite (float)
 
 ```
 download_tflite_models.sh
 python3 export_image_predictor.py --framework tflite --mode import
 python3 export_video_predictor.py --framework tflite --mode import
+```
+
+tflite (int8)
+
+```
+download_tflite_models.sh
+python3 export_image_predictor.py --framework tflite --mode import --accuracy int8 --image_size 512
+python3 export_video_predictor.py --framework tflite --mode import --accuracy int8 --image_size 512
 ```
 
 ailia_tflite
@@ -105,6 +121,8 @@ You can also download it from the following.
 
 ### TFLITE
 
+#### Float
+
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/image_encoder_hiera_t_2.1.tflite
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/prompt_encoder_hiera_t_2.1.tflite
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/mask_decoder_hiera_t_2.1.tflite
@@ -112,6 +130,16 @@ You can also download it from the following.
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_encoder_hiera_t_2.1.tflite
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_attention_hiera_t_2.1.tflite (4dim matmul, batch = 1, num_maskmem = 8)
 - https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/obj_ptr_tpos_proj_hiera_t_2.1.tflite
+
+#### Int8
+
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/image_encoder_hiera_t_2.1_512.int8.tflite
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/prompt_encoder_hiera_t_2.1_512.int8.tflite
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/mask_decoder_hiera_t_2.1_512.int8.tflite
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/mlp_hiera_t_2.1_512.int8.tflite
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_encoder_hiera_t_2.1_512.int8.tflite
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_attention_hiera_t_2.1_512.int8.tflite (4dim matmul, batch = 1, num_maskmem = 8)
+- https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/obj_ptr_tpos_proj_hiera_t_2.1_512.int8.tflite
 
 ## Inference Example
 

--- a/download_tflite_models.sh
+++ b/download_tflite_models.sh
@@ -12,3 +12,10 @@ wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/mlp
 wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_encoder_hiera_t_2.1_512.tflite -P ./model/
 wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_attention_hiera_t_2.1_512.tflite -P ./model/
 wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/obj_ptr_tpos_proj_hiera_t_2.1_512.tflite -P ./model/
+wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/image_encoder_hiera_t_2.1_512.int8.tflite -P ./model/
+wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/prompt_encoder_hiera_t_2.1_512.int8.tflite -P ./model/
+wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/mask_decoder_hiera_t_2.1_512.int8.tflite -P ./model/
+wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/mlp_hiera_t_2.1_512.int8.tflite -P ./model/
+wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_encoder_hiera_t_2.1_512.int8.tflite -P ./model/
+wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_attention_hiera_t_2.1_512.int8.tflite -P ./model/
+wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/obj_ptr_tpos_proj_hiera_t_2.1_512.int8.tflite -P ./model/

--- a/download_tflite_models.sh
+++ b/download_tflite_models.sh
@@ -19,3 +19,6 @@ wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/mlp
 wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_encoder_hiera_t_2.1_512.int8.tflite -P ./model/
 wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_attention_hiera_t_2.1_512.int8.tflite -P ./model/
 wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/obj_ptr_tpos_proj_hiera_t_2.1_512.int8.tflite -P ./model/
+wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/image_encoder_hiera_t_2.1_512.mixed.tflite -P ./model/
+wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/mask_decoder_hiera_t_2.1_512.mixed.tflite -P ./model/
+wget https://storage.googleapis.com/ailia-models-tflite/segment-anything-2.1/memory_attention_hiera_t_2.1_512.mixed.tflite -P ./model/

--- a/export_image_predictor.py
+++ b/export_image_predictor.py
@@ -5,7 +5,7 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('--model_id', default="hiera_t", choices=["hiera_l", "hiera_b+", "hiera_s", "hiera_t"])
 parser.add_argument('--framework', default="onnx", choices=["onnx", "tflite", "torch", "ailia_tflite"])
-parser.add_argument('--accuracy', default="float", choices=["float", "int8"])
+parser.add_argument('--accuracy', default="float", choices=["float", "int8", "mixed"])
 parser.add_argument('--mode', default="both", choices=["both", "import", "export", "calibration"])
 parser.add_argument('--image_size', default=1024, type=int, choices=[512, 1024])
 parser.add_argument('--version', default="2.1", choices=["2", "2.1"])
@@ -38,7 +38,7 @@ calibration = args.mode == "calibration"
 if args.framework=="ailia_tflite" and import_from_tflite:
     import_from_tflite = "ailia_tflite"
 
-tflite_int8 = args.accuracy == "int8"
+tflite_int8 = False if args.accuracy == "float" else args.accuracy
 
 # export PJRT_DEVICE=CPU
 
@@ -114,7 +114,7 @@ def show_masks(output_path, image, masks, scores, point_coords=None, box_coords=
             plt.title(f"Mask {i+1}, Score: {score:.3f}", fontsize=18)
         plt.axis('off')
         #plt.show()
-        plt.savefig(f'{output_path}{i+1}_'+model_id+'.png')
+        plt.savefig(f'{output_path}{i+1}_'+model_id+'.'+args.accuracy+'.png')
 
 # logic
 sam2_model = build_sam2(model_cfg, sam2_checkpoint, device=device, image_size=args.image_size)

--- a/export_image_predictor.py
+++ b/export_image_predictor.py
@@ -124,7 +124,8 @@ predictor = SAM2ImagePredictor(sam2_model, calibration=calibration)
 images = ['notebooks/images/truck.jpg']
 if calibration:
     import glob
-    images = glob.glob("./calibration/images/*.jpg")
+    #images = glob.glob("./calibration/images/*.jpg")
+    images = glob.glob("./calibration/images_large/*.jpg")
     if len(images) == 0:
         raise Exception("Calibration image not found. Please put images to ./calibration/images/")
 

--- a/export_image_predictor.py
+++ b/export_image_predictor.py
@@ -6,7 +6,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--model_id', default="hiera_t", choices=["hiera_l", "hiera_b+", "hiera_s", "hiera_t"])
 parser.add_argument('--framework', default="onnx", choices=["onnx", "tflite", "torch", "ailia_tflite"])
 parser.add_argument('--accuracy', default="float", choices=["float", "int8"])
-parser.add_argument('--mode', default="both", choices=["both", "import", "export"])
+parser.add_argument('--mode', default="both", choices=["both", "import", "export", "calibration"])
 parser.add_argument('--image_size', default=1024, type=int, choices=[512, 1024])
 parser.add_argument('--version', default="2.1", choices=["2", "2.1"])
 args = parser.parse_args()
@@ -32,6 +32,8 @@ import_from_onnx = args.framework == "onnx" and (args.mode=="import" or args.mod
 export_to_tflite_image_encoder = args.framework == "tflite" and (args.mode=="export" or args.mode=="both")
 export_to_tflite_mask_decoder = args.framework == "tflite" and (args.mode=="export" or args.mode=="both")
 import_from_tflite = (args.framework == "tflite" or args.framework == "ailia_tflite") and (args.mode=="import" or args.mode=="both")
+
+calibration = args.mode == "calibration"
 
 if args.framework=="ailia_tflite" and import_from_tflite:
     import_from_tflite = "ailia_tflite"
@@ -97,7 +99,7 @@ def show_box(box, ax):
     w, h = box[2] - box[0], box[3] - box[1]
     ax.add_patch(plt.Rectangle((x0, y0), w, h, edgecolor='green', facecolor=(0, 0, 0, 0), lw=2))    
 
-def show_masks(image, masks, scores, point_coords=None, box_coords=None, input_labels=None, borders=True, model_id=model_id):
+def show_masks(output_path, image, masks, scores, point_coords=None, box_coords=None, input_labels=None, borders=True, model_id=model_id):
     for i, (mask, score) in enumerate(zip(masks, scores)):
         plt.figure(figsize=(10, 10))
         plt.imshow(image)
@@ -112,40 +114,61 @@ def show_masks(image, masks, scores, point_coords=None, box_coords=None, input_l
             plt.title(f"Mask {i+1}, Score: {score:.3f}", fontsize=18)
         plt.axis('off')
         #plt.show()
-        plt.savefig(f'output/output{i+1}_'+model_id+'.png')
+        plt.savefig(f'{output_path}{i+1}_'+model_id+'.png')
 
 # logic
-image = Image.open('notebooks/images/truck.jpg')
-image = np.array(image.convert("RGB"))
-
 sam2_model = build_sam2(model_cfg, sam2_checkpoint, device=device, image_size=args.image_size)
 
-predictor = SAM2ImagePredictor(sam2_model)
+predictor = SAM2ImagePredictor(sam2_model, calibration=calibration)
 
-predictor.set_image(image, export_to_onnx = export_to_onnx_image_encoder,
-                    export_to_tflite = export_to_tflite_image_encoder,
-                    import_from_onnx = import_from_onnx, import_from_tflite = import_from_tflite,
-                    tflite_int8 = tflite_int8, model_id = model_id)
+images = ['notebooks/images/truck.jpg']
+if calibration:
+    import glob
+    images = glob.glob("./calibration/images/*.jpg")
+    if len(images) == 0:
+        raise Exception("Calibration image not found. Please put images to ./calibration/images/")
 
-input_point = np.array([[500, 375]])
-input_label = np.array([1])
+calibration_random = np.random.default_rng(1234)
 
-masks, scores, logits = predictor.predict(
-    point_coords=input_point,
-    point_labels=input_label,
-    multimask_output=True,
-    export_to_onnx=export_to_onnx_mask_decoder,
-    export_to_tflite=export_to_tflite_mask_decoder,
-    import_from_onnx=import_from_onnx,
-    import_from_tflite=import_from_tflite,
-    tflite_int8=tflite_int8,
-    model_id=model_id
-)
-sorted_ind = np.argsort(scores)[::-1]
-masks = masks[sorted_ind]
-scores = scores[sorted_ind]
-logits = logits[sorted_ind]
+for image_path in images:
+    print(image_path)
 
-show_masks(image, masks, scores, point_coords=input_point, input_labels=input_label, borders=True, model_id=model_id)
+    image = Image.open(image_path)
+    image = np.array(image.convert("RGB"))
+
+    predictor.set_image(image, export_to_onnx = export_to_onnx_image_encoder,
+                        export_to_tflite = export_to_tflite_image_encoder,
+                        import_from_onnx = import_from_onnx, import_from_tflite = import_from_tflite,
+                        tflite_int8 = tflite_int8, model_id = model_id)
+
+    input_point = np.array([[500, 375]])
+    input_label = np.array([1])
+
+    if calibration:
+        x = calibration_random.random()
+        y = calibration_random.random()
+        input_point = np.array([[int(image.shape[1] * x), int(image.shape[0] * y)]])
+
+    masks, scores, logits = predictor.predict(
+        point_coords=input_point,
+        point_labels=input_label,
+        multimask_output=True,
+        export_to_onnx=export_to_onnx_mask_decoder,
+        export_to_tflite=export_to_tflite_mask_decoder,
+        import_from_onnx=import_from_onnx,
+        import_from_tflite=import_from_tflite,
+        tflite_int8=tflite_int8,
+        model_id=model_id
+    )
+    sorted_ind = np.argsort(scores)[::-1]
+    masks = masks[sorted_ind]
+    scores = scores[sorted_ind]
+    logits = logits[sorted_ind]
+
+    output_path = "output/output"
+    if calibration:
+        os.makedirs("./calibration/output", exist_ok=True)
+        output_path = "./calibration/output/" + os.path.basename(image_path)
+    show_masks(output_path, image, masks, scores, point_coords=input_point, input_labels=input_label, borders=True, model_id=model_id)
 
 print("Success!")

--- a/export_video_predictor.py
+++ b/export_video_predictor.py
@@ -102,7 +102,7 @@ frame_names = [
 ]
 frame_names.sort(key=lambda p: int(os.path.splitext(p)[0]))
 
-inference_state = predictor.init_state(video_path=video_dir, import_from_onnx=import_from_onnx, import_from_tflite=import_from_tflite, model_id=model_id)
+inference_state = predictor.init_state(video_path=video_dir, import_from_onnx=import_from_onnx, import_from_tflite=import_from_tflite, tflite_int8=tflite_int8, model_id=model_id)
 predictor.reset_state(inference_state)
 
 ann_frame_idx = 0  # the frame index we interact with

--- a/export_video_predictor.py
+++ b/export_video_predictor.py
@@ -6,7 +6,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--model_id', default="hiera_t", choices=["hiera_l", "hiera_b+", "hiera_s", "hiera_t"])
 parser.add_argument('--framework', default="onnx", choices=["onnx", "tflite", "torch", "ailia_tflite"])
 parser.add_argument('--accuracy', default="float", choices=["float", "int8"])
-parser.add_argument('--mode', default="both", choices=["both", "import", "export"])
+parser.add_argument('--mode', default="both", choices=["both", "import", "export", "calibration"])
 parser.add_argument('--image_size', default=1024, type=int, choices=[512, 1024])
 parser.add_argument('--version', default="2.1", choices=["2", "2.1"])
 args = parser.parse_args()
@@ -27,6 +27,7 @@ import_from_onnx = args.framework=="onnx" and (args.mode=="import" or args.mode=
 export_to_tflite = args.framework=="tflite" and (args.mode=="export" or args.mode=="both")
 import_from_tflite = (args.framework=="tflite" or args.framework=="ailia_tflite") and (args.mode=="import" or args.mode=="both")
 tflite_int8 = (args.accuracy == "int8")
+calibration = args.mode == "calibration"
 
 if args.framework=="ailia_tflite" and import_from_tflite:
     import_from_tflite = "ailia_tflite"
@@ -60,7 +61,7 @@ print(f"using device: {device}")
 
 from sam2.build_sam import build_sam2_video_predictor
 
-predictor = build_sam2_video_predictor(model_cfg, sam2_checkpoint, device=device, image_size=args.image_size)
+predictor = build_sam2_video_predictor(model_cfg, sam2_checkpoint, device=device, image_size=args.image_size, calibration=calibration)
 
 #if export_to_tflite or import_from_tflite:
 #    predictor.set_num_maskmem(num_maskmem=1, max_obj_ptrs_in_encoder=1)

--- a/export_video_predictor.py
+++ b/export_video_predictor.py
@@ -92,6 +92,10 @@ def show_box(box, ax):
 
 video_dir = "./notebooks/videos/bedroom_short"
 
+if calibration:
+    #video_dir = "./calibration/images"
+    video_dir = "./calibration/images_large"
+
 # scan all the JPEG frame names in this directory
 frame_names = [
     p for p in os.listdir(video_dir)

--- a/export_video_predictor.py
+++ b/export_video_predictor.py
@@ -93,8 +93,7 @@ def show_box(box, ax):
 video_dir = "./notebooks/videos/bedroom_short"
 
 if calibration:
-    #video_dir = "./calibration/images"
-    video_dir = "./calibration/images_large"
+    video_dir = "./calibration/bedroom"
 
 # scan all the JPEG frame names in this directory
 frame_names = [

--- a/export_video_predictor.py
+++ b/export_video_predictor.py
@@ -5,7 +5,7 @@ import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('--model_id', default="hiera_t", choices=["hiera_l", "hiera_b+", "hiera_s", "hiera_t"])
 parser.add_argument('--framework', default="onnx", choices=["onnx", "tflite", "torch", "ailia_tflite"])
-parser.add_argument('--accuracy', default="float", choices=["float", "int8"])
+parser.add_argument('--accuracy', default="float", choices=["float", "int8", "mixed"])
 parser.add_argument('--mode', default="both", choices=["both", "import", "export", "calibration"])
 parser.add_argument('--image_size', default=1024, type=int, choices=[512, 1024])
 parser.add_argument('--version', default="2.1", choices=["2", "2.1"])
@@ -26,7 +26,7 @@ export_to_onnx = args.framework=="onnx" and (args.mode=="export" or args.mode=="
 import_from_onnx = args.framework=="onnx" and (args.mode=="import" or args.mode=="both")
 export_to_tflite = args.framework=="tflite" and (args.mode=="export" or args.mode=="both")
 import_from_tflite = (args.framework=="tflite" or args.framework=="ailia_tflite") and (args.mode=="import" or args.mode=="both")
-tflite_int8 = (args.accuracy == "int8")
+tflite_int8 = False if args.accuracy == "float" else args.accuracy
 calibration = args.mode == "calibration"
 
 if args.framework=="ailia_tflite" and import_from_tflite:
@@ -139,7 +139,7 @@ plt.imshow(Image.open(os.path.join(video_dir, frame_names[ann_frame_idx])))
 show_points(points, labels, plt.gca())
 show_mask((out_mask_logits[0] > 0.0).cpu().numpy(), plt.gca(), obj_id=out_obj_ids[0])
 #plt.show()
-plt.savefig(f'output/video_'+model_id+'.png')
+plt.savefig(f'output/video_'+model_id+'.'+args.accuracy+'.png')
 
 # run propagation throughout the video and collect the results in a dict
 video_segments = {}  # video_segments contains the per-frame segmentation results
@@ -159,4 +159,4 @@ for out_frame_idx in range(0, len(frame_names), vis_frame_stride):
     for out_obj_id, out_mask in video_segments[out_frame_idx].items():
         show_mask(out_mask, plt.gca(), obj_id=out_obj_id)
     #plt.show()
-    plt.savefig(f'output/video{out_frame_idx+1}_'+model_id+'.png')
+    plt.savefig(f'output/video{out_frame_idx+1}_'+model_id+'.'+args.accuracy+'.png')

--- a/export_video_predictor.py
+++ b/export_video_predictor.py
@@ -26,6 +26,7 @@ export_to_onnx = args.framework=="onnx" and (args.mode=="export" or args.mode=="
 import_from_onnx = args.framework=="onnx" and (args.mode=="import" or args.mode=="both")
 export_to_tflite = args.framework=="tflite" and (args.mode=="export" or args.mode=="both")
 import_from_tflite = (args.framework=="tflite" or args.framework=="ailia_tflite") and (args.mode=="import" or args.mode=="both")
+tflite_int8 = (args.accuracy == "int8")
 
 if args.framework=="ailia_tflite" and import_from_tflite:
     import_from_tflite = "ailia_tflite"
@@ -123,6 +124,7 @@ _, out_obj_ids, out_mask_logits = predictor.add_new_points_or_box(
     export_to_onnx=export_to_onnx,
     import_from_tflite=import_from_tflite,
     export_to_tflite=export_to_tflite,
+    tflite_int8=tflite_int8,
     model_id=model_id
 )
 
@@ -137,7 +139,7 @@ plt.savefig(f'output/video_'+model_id+'.png')
 
 # run propagation throughout the video and collect the results in a dict
 video_segments = {}  # video_segments contains the per-frame segmentation results
-for out_frame_idx, out_obj_ids, out_mask_logits in predictor.propagate_in_video(inference_state, import_from_onnx=import_from_onnx, export_to_onnx=export_to_onnx, import_from_tflite=import_from_tflite, export_to_tflite=export_to_tflite, model_id=model_id):
+for out_frame_idx, out_obj_ids, out_mask_logits in predictor.propagate_in_video(inference_state, import_from_onnx=import_from_onnx, export_to_onnx=export_to_onnx, import_from_tflite=import_from_tflite, export_to_tflite=export_to_tflite, tflite_int8=tflite_int8, model_id=model_id):
     video_segments[out_frame_idx] = {
         out_obj_id: (out_mask_logits[i] > 0.0).cpu().numpy()
         for i, out_obj_id in enumerate(out_obj_ids)

--- a/export_video_predictor.py
+++ b/export_video_predictor.py
@@ -111,7 +111,7 @@ ann_obj_id = 1  # give a unique id to each object we interact with (it can be an
 # Let's add a 2nd positive click at (x, y) = (250, 220) to refine the mask
 # sending all clicks (and their labels) to `add_new_points_or_box`
 # for labels, `1` means positive click and `0` means negative click
-if True:#args.framework == "tflite" or args.framework == "ailia_tflite":
+if False:#args.framework == "tflite" or args.framework == "ailia_tflite":
     points = np.array([[210, 350]], dtype=np.float32)
     labels = np.array([1], np.int32)
 else:

--- a/quantize.sh
+++ b/quantize.sh
@@ -1,0 +1,5 @@
+export PJRT_DEVICE=CPU
+python3 export_image_predictor.py --accuracy int8 --image_size 512 --mode calibration
+python3 export_video_predictor.py --accuracy int8 --image_size 512 --mode calibration
+python3 export_image_predictor.py --framework tflite --accuracy int8 --image_size 512
+python3 export_video_predictor.py --framework tflite --accuracy int8 --image_size 512

--- a/sam2/build_sam.py
+++ b/sam2/build_sam.py
@@ -107,6 +107,7 @@ def build_sam2_video_predictor(
     hydra_overrides_extra=[],
     apply_postprocessing=True,
     image_size=1024,
+    calibration=False,
     **kwargs,
 ):
     hydra_overrides = [
@@ -131,6 +132,7 @@ def build_sam2_video_predictor(
     cfg.model.image_size = image_size
     OmegaConf.resolve(cfg)
     model = instantiate(cfg.model, _recursive_=True)
+    model.calibration = calibration
     _load_checkpoint(model, ckpt_path)
     model = model.to(device)
     if mode == "eval":

--- a/sam2/build_sam.py
+++ b/sam2/build_sam.py
@@ -164,6 +164,10 @@ def _load_checkpoint(model, ckpt_path):
     if ckpt_path is not None:
         sd = torch.load(ckpt_path, map_location="cpu", weights_only=True)["model"]
         missing_keys, unexpected_keys = model.load_state_dict(sd)
+        for name, module in model.named_modules():
+            from sam2.modeling.sam2_utils import LayerNorm2dWithNN
+            if isinstance(module, LayerNorm2dWithNN):
+                module.load_weights_from_old_model()
         if missing_keys:
             logging.error(missing_keys)
             raise RuntimeError()

--- a/sam2/build_sam.py
+++ b/sam2/build_sam.py
@@ -165,8 +165,8 @@ def _load_checkpoint(model, ckpt_path):
         sd = torch.load(ckpt_path, map_location="cpu", weights_only=True)["model"]
         missing_keys, unexpected_keys = model.load_state_dict(sd)
         for name, module in model.named_modules():
-            from sam2.modeling.sam2_utils import LayerNorm2dWithNN
-            if isinstance(module, LayerNorm2dWithNN):
+            from sam2.modeling.sam2_utils import LayerNorm2dWithNN, LayerNorm2dWithNN3Dim
+            if isinstance(module, LayerNorm2dWithNN) or isinstance(module, LayerNorm2dWithNN3Dim):
                 module.load_weights_from_old_model()
         if missing_keys:
             logging.error(missing_keys)

--- a/sam2/modeling/memory_encoder.py
+++ b/sam2/modeling/memory_encoder.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from sam2.modeling.sam2_utils import DropPath, get_clones, LayerNorm2d
+from sam2.modeling.sam2_utils import DropPath, get_clones, LayerNorm2d, LayerNorm2dNHWC
 
 
 class MaskDownSampler(nn.Module):
@@ -48,7 +48,7 @@ class MaskDownSampler(nn.Module):
                     padding=padding,
                 )
             )
-            self.encoder.append(LayerNorm2d(mask_out_chans))
+            self.encoder.append(LayerNorm2dNHWC(mask_out_chans))
             self.encoder.append(activation())
             mask_in_chans = mask_out_chans
 
@@ -88,7 +88,7 @@ class CXBlock(nn.Module):
             padding=padding,
             groups=dim if use_dwconv else 1,
         )  # depthwise conv
-        self.norm = LayerNorm2d(dim, eps=1e-6)
+        self.norm = LayerNorm2dNHWC(dim, eps=1e-6)
         self.pwconv1 = nn.Linear(
             dim, 4 * dim
         )  # pointwise/1x1 convs, implemented with linear layers

--- a/sam2/modeling/memory_encoder.py
+++ b/sam2/modeling/memory_encoder.py
@@ -154,6 +154,15 @@ class MemoryEncoder(nn.Module):
         self.out_proj = nn.Identity()
         if out_dim != in_dim:
             self.out_proj = nn.Conv2d(in_dim, out_dim, kernel_size=1)
+        self.pos_cache_enable = False
+        self.pos_cache = None
+
+    def prepare_position_encoding(self, pix_feat: torch.Tensor):
+        x = self.pix_feat_proj(pix_feat)
+        x = self.fuser(x)
+        x = self.out_proj(x)
+        self.pos_cache_enable = True
+        self.pos_cache = self.position_encoding(x).to(x.dtype)
 
     def forward(
         self,
@@ -177,7 +186,8 @@ class MemoryEncoder(nn.Module):
         x = self.fuser(x)
         x = self.out_proj(x)
 
-        pos = self.position_encoding(x).to(x.dtype)
+        assert(self.pos_cache_enable)
+        pos = self.pos_cache
 
         return x, pos
         

--- a/sam2/modeling/memory_encoder.py
+++ b/sam2/modeling/memory_encoder.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from sam2.modeling.sam2_utils import DropPath, get_clones, LayerNorm2d, LayerNorm2dNHWC
+from sam2.modeling.sam2_utils import DropPath, get_clones, LayerNorm2d, LayerNorm2dWithNN
 
 
 class MaskDownSampler(nn.Module):
@@ -48,7 +48,7 @@ class MaskDownSampler(nn.Module):
                     padding=padding,
                 )
             )
-            self.encoder.append(LayerNorm2dNHWC(mask_out_chans))
+            self.encoder.append(LayerNorm2dWithNN(mask_out_chans))
             self.encoder.append(activation())
             mask_in_chans = mask_out_chans
 
@@ -88,7 +88,7 @@ class CXBlock(nn.Module):
             padding=padding,
             groups=dim if use_dwconv else 1,
         )  # depthwise conv
-        self.norm = LayerNorm2dNHWC(dim, eps=1e-6)
+        self.norm = LayerNorm2dWithNN(dim, eps=1e-6)
         self.pwconv1 = nn.Linear(
             dim, 4 * dim
         )  # pointwise/1x1 convs, implemented with linear layers

--- a/sam2/modeling/position_encoding.py
+++ b/sam2/modeling/position_encoding.py
@@ -162,8 +162,8 @@ class PositionEmbeddingRandom(nn.Module):
         """Positionally encode points that are not normalized to [0,1]."""
         coords = coords_input.clone()
         #coords[:, :, 0] = coords[:, :, 0] / image_size[1] # このままだと順番に書き換えるためにselectv2が生成される
-        #coords[:, :, 1] = coords[:, :, 1] / image_size[0]
-        coords[:, :, :2] /= torch.tensor(image_size[::-1])
+        #coords[:, :, 1] = coords[:, :, 1] / image_size[0] # その結果、量子化係数を適切に決定できず、リスケーリング後に0に落ちる
+        coords[:, :, :2] /= torch.tensor(image_size[::-1], dtype = torch.float32)
         return self._pe_encoding(coords.to(torch.float))  # B x N x C
 
 

--- a/sam2/modeling/position_encoding.py
+++ b/sam2/modeling/position_encoding.py
@@ -137,7 +137,7 @@ class PositionEmbeddingRandom(nn.Module):
     def _pe_encoding(self, coords: torch.Tensor) -> torch.Tensor:
         """Positionally encode points that are normalized to [0,1]."""
         # assuming coords are in [0, 1]^2 square and have d_1 x ... x d_n x 2 shape
-        coords = 2 * coords - 1
+        coords = 2.0 * coords - 1 # 2だとint32 x int32になりtorchの量子化に失敗する
         coords = coords @ self.positional_encoding_gaussian_matrix
         coords = 2 * np.pi * coords
         # outputs d_1 x ... x d_n x C shape

--- a/sam2/modeling/position_encoding.py
+++ b/sam2/modeling/position_encoding.py
@@ -161,8 +161,9 @@ class PositionEmbeddingRandom(nn.Module):
     ) -> torch.Tensor:
         """Positionally encode points that are not normalized to [0,1]."""
         coords = coords_input.clone()
-        coords[:, :, 0] = coords[:, :, 0] / image_size[1]
-        coords[:, :, 1] = coords[:, :, 1] / image_size[0]
+        #coords[:, :, 0] = coords[:, :, 0] / image_size[1] # このままだと順番に書き換えるためにselectv2が生成される
+        #coords[:, :, 1] = coords[:, :, 1] / image_size[0]
+        coords[:, :, :2] /= torch.tensor(image_size[::-1])
         return self._pe_encoding(coords.to(torch.float))  # B x N x C
 
 

--- a/sam2/modeling/sam/mask_decoder.py
+++ b/sam2/modeling/sam/mask_decoder.py
@@ -116,8 +116,9 @@ class MaskDecoder(nn.Module):
         dense_prompt_embeddings: torch.Tensor,
         multimask_output: bool,
         repeat_image: bool,
-        high_res_features1: Optional[torch.Tensor] = None,
-        high_res_features2: Optional[torch.Tensor] = None,
+        high_res_features1: Optional[torch.Tensor],
+        high_res_features2: Optional[torch.Tensor],
+        attn_masks: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Predict masks given image and prompt embeddings.
@@ -143,6 +144,7 @@ class MaskDecoder(nn.Module):
             repeat_image=repeat_image,
             high_res_features1=high_res_features1,
             high_res_features2=high_res_features2,
+            attn_masks=attn_masks
         )
 
         # Select the correct mask or masks for output
@@ -176,8 +178,9 @@ class MaskDecoder(nn.Module):
         sparse_prompt_embeddings: torch.Tensor,
         dense_prompt_embeddings: torch.Tensor,
         repeat_image: bool,
-        high_res_features1: Optional[torch.Tensor] = None,
-        high_res_features2: Optional[torch.Tensor] = None,
+        high_res_features1: Optional[torch.Tensor],
+        high_res_features2: Optional[torch.Tensor],
+        attn_masks: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         masks, iou_pred, mask_tokens_out, object_score_logits = self.predict_masks(
             image_embeddings=image_embeddings,
@@ -187,6 +190,7 @@ class MaskDecoder(nn.Module):
             repeat_image=repeat_image,
             high_res_features1=high_res_features1,
             high_res_features2=high_res_features2,
+            attn_masks=attn_masks
         )
         return masks, iou_pred, mask_tokens_out, object_score_logits
 
@@ -228,8 +232,9 @@ class MaskDecoder(nn.Module):
         sparse_prompt_embeddings: torch.Tensor,
         dense_prompt_embeddings: torch.Tensor,
         repeat_image: bool,
-        high_res_features1: Optional[torch.Tensor] = None,
-        high_res_features2: Optional[torch.Tensor] = None,
+        high_res_features1: Optional[torch.Tensor],
+        high_res_features2: Optional[torch.Tensor],
+        attn_masks: torch.Tensor, # for sparse_prompt_embeddings
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Predicts masks. See 'forward' for more details."""
         # Concatenate output tokens
@@ -251,8 +256,10 @@ class MaskDecoder(nn.Module):
         output_tokens = output_tokens.unsqueeze(0).expand(
             sparse_prompt_embeddings.shape[0], -1, -1
         )
+        output_tokens_attn_masks = torch.ones((output_tokens.shape[0], output_tokens.shape[1]), dtype=torch.bool)
         tokens = torch.cat((output_tokens, sparse_prompt_embeddings), dim=1)
-
+        tokens_attn_masks = torch.concat((output_tokens_attn_masks, attn_masks), dim = 1)
+        
         # Expand per-image data in batch direction to be per-mask
         if repeat_image:
             src = torch.repeat_interleave(image_embeddings, tokens.shape[0], dim=0)
@@ -272,7 +279,7 @@ class MaskDecoder(nn.Module):
         b, c, h, w = src.shape
 
         # Run the transformer
-        hs, src = self.transformer(src, pos_src, tokens)
+        hs, src = self.transformer(src, pos_src, tokens, tokens_attn_masks)
         iou_token_out = hs[:, s, :]
         mask_tokens_out = hs[:, s + 1 : (s + 1 + self.num_mask_tokens), :]
 

--- a/sam2/modeling/sam/mask_decoder.py
+++ b/sam2/modeling/sam/mask_decoder.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Tuple, Type
 import torch
 from torch import nn
 
-from sam2.modeling.sam2_utils import LayerNorm2d, MLP
+from sam2.modeling.sam2_utils import LayerNorm2d, LayerNorm2dWithNN, MLP
 
 
 class MaskDecoder(nn.Module):
@@ -66,7 +66,7 @@ class MaskDecoder(nn.Module):
             nn.ConvTranspose2d(
                 transformer_dim, transformer_dim // 4, kernel_size=2, stride=2
             ),
-            LayerNorm2d(transformer_dim // 4),
+            LayerNorm2dWithNN(transformer_dim // 4),
             activation(),
             nn.ConvTranspose2d(
                 transformer_dim // 4, transformer_dim // 8, kernel_size=2, stride=2

--- a/sam2/modeling/sam/prompt_encoder.py
+++ b/sam2/modeling/sam/prompt_encoder.py
@@ -56,14 +56,17 @@ class PromptEncoder(nn.Module):
         )
         self.mask_downscaling = nn.Sequential(
             nn.Conv2d(1, mask_in_chans // 4, kernel_size=2, stride=2),
-            LayerNorm2d(mask_in_chans // 4),
+            LayerNorm2dWithNN3Dim(mask_in_chans // 4),
             activation(),
             nn.Conv2d(mask_in_chans // 4, mask_in_chans, kernel_size=2, stride=2),
-            LayerNorm2d(mask_in_chans),
+            LayerNorm2dWithNN3Dim(mask_in_chans),
             activation(),
             nn.Conv2d(mask_in_chans, embed_dim, kernel_size=1),
         )
         self.no_mask_embed = nn.Embedding(1, embed_dim)
+        self.dense_pe = None
+    
+    def generate_dense_pe(self):
         self.dense_pe = self.pe_layer(self.image_embedding_size).unsqueeze(0) # constantにする
 
     def get_dense_pe(self) -> torch.Tensor:
@@ -75,6 +78,7 @@ class PromptEncoder(nn.Module):
           torch.Tensor: Positional encoding with shape
             1x(embed_dim)x(embedding_h)x(embedding_w)
         """
+        #assert(self.dense_pe != None)
         return self.dense_pe
 
     def _embed_points(

--- a/sam2/modeling/sam/prompt_encoder.py
+++ b/sam2/modeling/sam/prompt_encoder.py
@@ -11,7 +11,7 @@ from torch import nn
 
 from sam2.modeling.position_encoding import PositionEmbeddingRandom
 
-from sam2.modeling.sam2_utils import LayerNorm2d
+from sam2.modeling.sam2_utils import LayerNorm2d, LayerNorm2dWithNN3Dim
 
 
 class PromptEncoder(nn.Module):
@@ -64,6 +64,7 @@ class PromptEncoder(nn.Module):
             nn.Conv2d(mask_in_chans, embed_dim, kernel_size=1),
         )
         self.no_mask_embed = nn.Embedding(1, embed_dim)
+        self.dense_pe = self.pe_layer(self.image_embedding_size).unsqueeze(0) # constantにする
 
     def get_dense_pe(self) -> torch.Tensor:
         """
@@ -74,7 +75,7 @@ class PromptEncoder(nn.Module):
           torch.Tensor: Positional encoding with shape
             1x(embed_dim)x(embedding_h)x(embedding_w)
         """
-        return self.pe_layer(self.image_embedding_size).unsqueeze(0)
+        return self.dense_pe
 
     def _embed_points(
         self,

--- a/sam2/modeling/sam/transformer.py
+++ b/sam2/modeling/sam/transformer.py
@@ -132,7 +132,7 @@ class TwoWayTransformer(nn.Module):
         # Apply the final attention layer from the points to the image
         q = queries + point_embedding
         k = keys + image_pe
-        attn_out = self.final_attn_token_to_image.cross_attn(q=q, k=k, v=keys)
+        attn_out = self.final_attn_token_to_image.forward_without_attn_mask(q=q, k=k, v=keys)
         queries = queries + attn_out
         queries = self.norm_final_attn(queries)
 
@@ -188,10 +188,10 @@ class TwoWayAttentionBlock(nn.Module):
     ) -> Tuple[Tensor, Tensor]:
         # Self attention block
         if self.skip_first_layer_pe:
-            queries = self.self_attn.self_attn(q=queries, k=queries, v=queries, attn_mask=attn_mask)
+            queries = self.self_attn.forward_with_attn_mask(q=queries, k=queries, v=queries, attn_mask=attn_mask)
         else:
             q = queries + query_pe
-            attn_out = self.self_attn.self_attn(q=q, k=q, v=queries, attn_mask=attn_mask)
+            attn_out = self.self_attn.forward_with_attn_mask(q=q, k=q, v=queries, attn_mask=attn_mask)
             queries = queries + attn_out
         queries = self.norm1(queries)
 
@@ -200,7 +200,7 @@ class TwoWayAttentionBlock(nn.Module):
         k = keys + key_pe
         
         #print(q.shape, m.shape)
-        attn_out = self.cross_attn_token_to_image.cross_attn(q=q, k=k, v=keys)
+        attn_out = self.cross_attn_token_to_image.forward_without_attn_mask(q=q, k=k, v=keys)
         queries = queries + attn_out
         queries = self.norm2(queries)
 
@@ -212,7 +212,7 @@ class TwoWayAttentionBlock(nn.Module):
         # Cross attention block, image embedding attending to tokens
         q = queries + query_pe
         k = keys + key_pe
-        attn_out = self.cross_attn_image_to_token.cross_attn(q=k, k=q, v=queries)
+        attn_out = self.cross_attn_image_to_token.forward_with_attn_mask(q=k, k=q, v=queries, attn_mask=attn_mask)
         keys = keys + attn_out
         keys = self.norm4(keys)
 
@@ -259,7 +259,7 @@ class Attention(nn.Module):
         x = x.transpose(1, 2)
         return x.reshape(b, n_tokens, n_heads * c_per_head)  # B x N_tokens x C
 
-    def self_attn(self, q: Tensor, k: Tensor, v: Tensor, attn_mask: Tensor) -> Tensor:
+    def forward_with_attn_mask(self, q: Tensor, k: Tensor, v: Tensor, attn_mask: Tensor) -> Tensor:
         # Input projections
         q = self.q_proj(q)
         k = self.k_proj(k)
@@ -293,7 +293,7 @@ class Attention(nn.Module):
 
         return out
 
-    def cross_attn(self, q: Tensor, k: Tensor, v: Tensor) -> Tensor:
+    def forward_without_attn_mask(self, q: Tensor, k: Tensor, v: Tensor) -> Tensor:
         # Input projections
         q = self.q_proj(q)
         k = self.k_proj(k)

--- a/sam2/modeling/sam/transformer.py
+++ b/sam2/modeling/sam/transformer.py
@@ -95,6 +95,7 @@ class TwoWayTransformer(nn.Module):
         image_embedding: Tensor,
         image_pe: Tensor,
         point_embedding: Tensor,
+        point_embedding_attn_mask: Tensor
     ) -> Tuple[Tensor, Tensor]:
         """
         Args:
@@ -125,12 +126,13 @@ class TwoWayTransformer(nn.Module):
                 keys=keys,
                 query_pe=point_embedding,
                 key_pe=image_pe,
+                attn_mask=point_embedding_attn_mask
             )
 
         # Apply the final attention layer from the points to the image
         q = queries + point_embedding
         k = keys + image_pe
-        attn_out = self.final_attn_token_to_image(q=q, k=k, v=keys)
+        attn_out = self.final_attn_token_to_image.cross_attn(q=q, k=k, v=keys)
         queries = queries + attn_out
         queries = self.norm_final_attn(queries)
 
@@ -182,21 +184,23 @@ class TwoWayAttentionBlock(nn.Module):
         self.skip_first_layer_pe = skip_first_layer_pe
 
     def forward(
-        self, queries: Tensor, keys: Tensor, query_pe: Tensor, key_pe: Tensor
+        self, queries: Tensor, keys: Tensor, query_pe: Tensor, key_pe: Tensor, attn_mask:Tensor
     ) -> Tuple[Tensor, Tensor]:
         # Self attention block
         if self.skip_first_layer_pe:
-            queries = self.self_attn(q=queries, k=queries, v=queries)
+            queries = self.self_attn.self_attn(q=queries, k=queries, v=queries, attn_mask=attn_mask)
         else:
             q = queries + query_pe
-            attn_out = self.self_attn(q=q, k=q, v=queries)
+            attn_out = self.self_attn.self_attn(q=q, k=q, v=queries, attn_mask=attn_mask)
             queries = queries + attn_out
         queries = self.norm1(queries)
 
         # Cross attention block, tokens attending to image embedding
         q = queries + query_pe
         k = keys + key_pe
-        attn_out = self.cross_attn_token_to_image(q=q, k=k, v=keys)
+        
+        #print(q.shape, m.shape)
+        attn_out = self.cross_attn_token_to_image.cross_attn(q=q, k=k, v=keys)
         queries = queries + attn_out
         queries = self.norm2(queries)
 
@@ -208,7 +212,7 @@ class TwoWayAttentionBlock(nn.Module):
         # Cross attention block, image embedding attending to tokens
         q = queries + query_pe
         k = keys + key_pe
-        attn_out = self.cross_attn_image_to_token(q=k, k=q, v=queries)
+        attn_out = self.cross_attn_image_to_token.cross_attn(q=k, k=q, v=queries)
         keys = keys + attn_out
         keys = self.norm4(keys)
 
@@ -255,7 +259,41 @@ class Attention(nn.Module):
         x = x.transpose(1, 2)
         return x.reshape(b, n_tokens, n_heads * c_per_head)  # B x N_tokens x C
 
-    def forward(self, q: Tensor, k: Tensor, v: Tensor) -> Tensor:
+    def self_attn(self, q: Tensor, k: Tensor, v: Tensor, attn_mask: Tensor) -> Tensor:
+        # Input projections
+        q = self.q_proj(q)
+        k = self.k_proj(k)
+        v = self.v_proj(v)
+
+        # Separate into heads
+        q = self._separate_heads(q, self.num_heads)
+        k = self._separate_heads(k, self.num_heads)
+        v = self._separate_heads(v, self.num_heads)
+
+        dropout_p = self.dropout_p if self.training else 0.0
+        # Attention
+        #try:
+        #    with sdp_kernel_context(dropout_p):
+        #        out = F.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p)
+        #except Exception as e:
+        if True:
+            # Fall back to all kernels if the Flash attention kernel fails
+            #warnings.warn(
+            #    f"Flash Attention kernel failed due to: {e}\nFalling back to all available "
+            #    f"kernels for scaled_dot_product_attention (which may have a slower speed).",
+            #    category=UserWarning,
+            #    stacklevel=2,
+            #)
+            global ALLOW_ALL_KERNELS
+            ALLOW_ALL_KERNELS = True
+            out = F.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p, attn_mask=attn_mask)
+
+        out = self._recombine_heads(out)
+        out = self.out_proj(out)
+
+        return out
+
+    def cross_attn(self, q: Tensor, k: Tensor, v: Tensor) -> Tensor:
         # Input projections
         q = self.q_proj(q)
         k = self.k_proj(k)

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -1276,14 +1276,14 @@ class SAM2Base(torch.nn.Module):
                     import numpy as np
                     for i in range(len(images)):
                         npz = np.load(images[i])
-                        data_0 = npz["arr_0"]
-                        data_1 = npz["arr_1"]
-                        data_2 = npz["arr_2"]
-                        data_3 = npz["arr_3"]
-                        data_4 = npz["arr_4"]
-                        data_5 = npz["arr_5"]
-                        data_6 = npz["arr_6"]
-                        data_7 = npz["arr_7"]
+                        data_0 = torch.tensor(npz["arr_0"])
+                        data_1 = torch.tensor(npz["arr_1"])
+                        data_2 = torch.tensor(npz["arr_2"])
+                        data_3 = torch.tensor(npz["arr_3"])
+                        data_4 = torch.tensor(npz["arr_4"])
+                        data_5 = torch.tensor(npz["arr_5"])
+                        data_6 = torch.tensor(npz["arr_6"])
+                        data_7 = torch.tensor(npz["arr_7"])
                         model(data_0, data_1, data_2, data_3, data_4, data_5, data_6, data_7)
 
                     #model(current_vision_feats[0], memory_1, memory_2, current_vision_pos_embeds[0], memory_pos_embed_1, memory_pos_embed_2, attention_mask_1, attention_mask_2)

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -1359,10 +1359,13 @@ class SAM2Base(torch.nn.Module):
 
         if export_to_tflite and not self.memory_encoder_tflite_exported:
             self.memory_encoder_tflite_exported = True
+
+            import ai_edge_torch
+            import tensorflow as tf
+
+            sample_inputs = (pix_feat, mask_for_mem)
+
             if not tflite_int8:
-                import ai_edge_torch
-                import tensorflow as tf
-                sample_inputs = (pix_feat, mask_for_mem)
                 tfl_converter_flags = {'target_spec': {'supported_ops': [tf.lite.OpsSet.TFLITE_BUILTINS]}}
                 edge_model = ai_edge_torch.convert(self.memory_encoder, sample_inputs, _ai_edge_converter_flags=tfl_converter_flags)
                 edge_model.export("model/memory_encoder_"+model_id+".tflite")
@@ -1383,7 +1386,7 @@ class SAM2Base(torch.nn.Module):
                 }
 
                 tfl_fullint_model = ai_edge_torch.convert(
-                    self.memory_attention, sample_inputs, _ai_edge_converter_flags=tfl_converter_flags
+                    self.memory_encoder, sample_inputs, _ai_edge_converter_flags=tfl_converter_flags
                 )
 
                 tfl_fullint_model.export("model/memory_encoder_"+model_id+".int8.tflite")

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -602,6 +602,7 @@ class SAM2Base(torch.nn.Module):
             else:
                 mask_input_dummy = sam_mask_prompt
                 masks_enable = torch.tensor([1], dtype=torch.int)
+            self.sam_prompt_encoder.generate_dense_pe()
             sparse_embeddings, dense_embeddings, dense_pe = self.sam_prompt_encoder.forward(
                 coords=sam_point_coords,
                 labels=sam_point_labels,

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -435,6 +435,20 @@ class SAM2Base(torch.nn.Module):
             mask_input_dummy = sam_mask_prompt
             masks_enable = torch.tensor([1], dtype=torch.int)
 
+        # padding
+        convert_to_static_shape = export_to_tflite or import_from_tflite or self.calibration
+        original_sparse_embedding_length = sam_point_coords.shape[1] + 1
+        max_sparse_embedding_length = 32
+
+        if convert_to_static_shape:
+            padding_length= max_sparse_embedding_length - 1
+            sam_point_coords_pad = torch.zeros(sam_point_coords.shape[0], padding_length, sam_point_coords.shape[2])
+            sam_point_labels_pad = -torch.ones(sam_point_labels.shape[0], padding_length)
+            sam_point_coords_pad[:, 0:sam_point_coords.shape[1], :] = sam_point_coords
+            sam_point_labels_pad[:, 0:sam_point_labels.shape[1]] = sam_point_labels
+            sam_point_coords = sam_point_coords_pad
+            sam_point_labels = sam_point_labels_pad
+
         if import_from_onnx:
             if self.debug:
                 print("begin prompt encoder onnx")
@@ -465,7 +479,8 @@ class SAM2Base(torch.nn.Module):
                 "dense_prompt_embeddings": dense_embeddings.numpy(),
                 #repeat_image=False,  # the image is already batched
                 "high_res_features1":high_res_features[0].numpy(),
-                "high_res_features2":high_res_features[1].numpy()})
+                "high_res_features2":high_res_features[1].numpy(),
+                "attn_masks":attn_masks.numpy()})
             masks = torch.Tensor(masks)
             iou_pred = torch.Tensor(iou_pred)
             sam_tokens_out = torch.Tensor(sam_tokens_out)
@@ -528,6 +543,20 @@ class SAM2Base(torch.nn.Module):
                 dense_embeddings = self.prompt_encoder_tflite.get_tensor(output_details[0]["index"])
                 dense_pe = self.prompt_encoder_tflite.get_tensor(output_details[2]["index"])
 
+            if convert_to_static_shape:
+                sparse_embeddings = sparse_embeddings[:, :original_sparse_embedding_length, :]
+
+            # Prepare attn_mask for mask decoder
+            if convert_to_static_shape:
+                max_num_sparse_embeddings = max_sparse_embedding_length
+                sparse_embeddings_pad = np.zeros((sparse_embeddings.shape[0], max_num_sparse_embeddings, sparse_embeddings.shape[2]))
+                sparse_embeddings_pad[:,:sparse_embeddings.shape[1],:] = sparse_embeddings
+                attn_masks = np.zeros((sparse_embeddings_pad.shape[0], sparse_embeddings_pad.shape[1]), dtype=np.bool8)
+                attn_masks[:,:sparse_embeddings.shape[1]] = True
+                sparse_embeddings = sparse_embeddings_pad
+            else:
+                attn_masks = np.ones((sparse_embeddings.shape[0], sparse_embeddings.shape[1]), dtype=np.bool8)
+
             if self.mask_decoder_tflite == None:
                 int8_id = ""
                 if tflite_int8:
@@ -560,6 +589,7 @@ class SAM2Base(torch.nn.Module):
                 self.mask_decoder_tflite.set_tensor(input_details[5]["index"], batched_mode)
                 self.mask_decoder_tflite.set_tensor(input_details[0]["index"], self.format_input_tensor(high_res_features[0].numpy(), input_details, 0))
                 self.mask_decoder_tflite.set_tensor(input_details[4]["index"], self.format_input_tensor(high_res_features[1].numpy(), input_details, 4))
+                self.mask_decoder_tflite.set_tensor(input_details[7]["index"], self.format_input_tensor(attn_masks, input_details, 7))
                 self.mask_decoder_tflite.invoke()
 
                 masks = self.get_output_tensor(self.mask_decoder_tflite, output_details, 2)
@@ -574,6 +604,7 @@ class SAM2Base(torch.nn.Module):
                 self.mask_decoder_tflite.set_tensor(input_details[5]["index"], batched_mode)
                 self.mask_decoder_tflite.set_tensor(input_details[0]["index"], high_res_features[0].numpy())
                 self.mask_decoder_tflite.set_tensor(input_details[4]["index"], high_res_features[1].numpy())
+                self.mask_decoder_tflite.set_tensor(input_details[7]["index"], attn_masks)
                 self.mask_decoder_tflite.invoke()
 
                 masks = self.mask_decoder_tflite.get_tensor(output_details[2]["index"])

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -1302,9 +1302,46 @@ class SAM2Base(torch.nn.Module):
                     from ai_edge_torch.quantize import quant_config
                     from torch.ao.quantization import quantize_pt2e
 
-                    quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
-                        pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
-                    )
+                    # torch quantization
+                    from ai_edge_torch.quantize import pt2e_quantizer
+                    from ai_edge_torch.quantize import quant_config
+                    from torch.ao.quantization import quantize_pt2e
+
+                    # quantize transpose_conv
+                    from ai_edge_torch.quantize.pt2e_quantizer_utils import get_input_act_qspec, get_weight_qspec, get_bias_qspec, get_output_act_qspec
+                    from torch.ao.quantization.quantizer import QuantizationAnnotation
+
+                    quantization_config = pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
+
+                    class PT2EQuantizer2(pt2e_quantizer.PT2EQuantizer):
+                        def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                            super().annotate(model)
+
+                            target_node = None
+                            for n in model.graph.nodes:
+                                if str(n.target) == "output":
+                                    target_node = n.args[0][0]
+
+                            for n in model.graph.nodes:
+                                if n == target_node:
+                                    input_qspec_map = {}
+                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                        input_qspec_map=input_qspec_map,
+                                        output_qspec=get_output_act_qspec(quantization_config),
+                                        _annotated=True,
+                                    )
+
+                            return model
+
+                    if False:
+                        quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
+                            quantization_config
+                        )
+                    else:
+                        quantizer = PT2EQuantizer2().set_global(
+                            quantization_config
+                        )
                     model = torch._export.capture_pre_autograd_graph(self.memory_attention, sample_inputs)
                     model = quantize_pt2e.prepare_pt2e(model, quantizer)
 

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -1584,42 +1584,44 @@ class SAM2Base(torch.nn.Module):
                     from ai_edge_torch.quantize import quant_config
                     from torch.ao.quantization import quantize_pt2e
 
-                    if True:
+                    quantization_config = pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
+
+                    if False:
                         quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
                             pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
                         )
                     else:
+                        import ai_edge_torch
+
+                        # torch quantization
+                        from ai_edge_torch.quantize import pt2e_quantizer
+                        from ai_edge_torch.quantize import quant_config
+                        from torch.ao.quantization import quantize_pt2e
+
+                        # quantize transpose_conv
+                        from ai_edge_torch.quantize.pt2e_quantizer_utils import get_input_act_qspec, get_output_act_qspec
+                        from torch.ao.quantization.quantizer import QuantizationAnnotation
+
                         class PT2EQuantizer2(pt2e_quantizer.PT2EQuantizer):
                             def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
                                 super().annotate(model)
+
                                 for n in model.graph.nodes:
-                                    print(n.target, n.meta)
-                                    if n.target in [torch.ops.aten.add.Tensor, torch.ops.aten.mean.dim]:
-                                        if "quantization_annotation" in n.meta and ("s = s + self.eps" in n.meta["stack_trace"] or "u = x.mean(3, keepdim=True)" in n.meta["stack_trace"]):
-                                            print(n.target)
-                                            print("Before")
-                                            print(n.meta["quantization_annotation"])
+                                    if n.target in [torch.ops.aten.gelu.default]:
+                                        input_qspec_map = {}
 
-                                            from torch.ao.quantization.quantizer import QuantizationSpec
-                                            from torch.ao.quantization.observer import PlaceholderObserver
-                                            act_observer_or_fake_quant_ctr = PlaceholderObserver
+                                        input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
 
-                                            float_spec = QuantizationSpec(dtype=torch.float32,
-                                                observer_or_fake_quant_ctr=act_observer_or_fake_quant_ctr.with_args(
-                                                eps=2**-12
-                                            ),)
+                                        n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                            input_qspec_map=input_qspec_map,
+                                            output_qspec=get_output_act_qspec(quantization_config),
+                                            _annotated=True,
+                                        )
 
-                                            for key in n.meta["quantization_annotation"].input_qspec_map:
-                                                n.meta["quantization_annotation"].input_qspec_map[key] = float_spec
-
-                                            n.meta["quantization_annotation"].output_qspec = float_spec
-
-                                            print("After")
-                                            print(n.meta["quantization_annotation"])
                                 return model
 
                         quantizer = PT2EQuantizer2().set_global(
-                            pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
+                            quantization_config
                         )
 
                     model = torch._export.capture_pre_autograd_graph(self.memory_encoder, sample_inputs)

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -1565,6 +1565,8 @@ class SAM2Base(torch.nn.Module):
         #if tflite_int8_memory_encoder == "mixed":
         #    tflite_int8_memory_encoder = "int8" # 暫定
 
+        self.memory_encoder.prepare_position_encoding(pix_feat)
+
         if export_to_tflite and not self.memory_encoder_tflite_exported:
             self.memory_encoder_tflite_exported = True
 

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -1584,7 +1584,7 @@ class SAM2Base(torch.nn.Module):
                     from ai_edge_torch.quantize import quant_config
                     from torch.ao.quantization import quantize_pt2e
 
-                    if False:
+                    if True:
                         quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
                             pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
                         )

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -610,6 +610,8 @@ class SAM2Base(torch.nn.Module):
                 masks_enable=masks_enable
             )
 
+            attn_masks = torch.ones((sparse_embeddings.shape[0], sparse_embeddings.shape[1]), dtype=torch.bool)
+
             (
                 low_res_multimasks,
                 ious,
@@ -624,6 +626,7 @@ class SAM2Base(torch.nn.Module):
                 repeat_image=False,  # the image is already batched
                 high_res_features1=high_res_features[0],
                 high_res_features2=high_res_features[1],
+                attn_masks=attn_masks
             )
             if self.debug:
                 print(low_res_multimasks.shape)

--- a/sam2/modeling/sam2_utils.py
+++ b/sam2/modeling/sam2_utils.py
@@ -159,7 +159,7 @@ class LayerNorm2dNHWC(nn.Module):
         self.bias = nn.Parameter(torch.zeros(num_channels))
         self.eps = eps
 
-    # for MINCUT
+    # for AIEDGETORCH_LAYOUT_OPTIMIZE_PARTITIONER=MINCUT
     def forward(self, x: torch.Tensor) -> torch.Tensor:
        # Turn into `NHWC` if required or any other specific format
        x = x.permute(0, 2, 3, 1)  # Optional based on requirements

--- a/sam2/modeling/sam2_utils.py
+++ b/sam2/modeling/sam2_utils.py
@@ -145,13 +145,27 @@ class LayerNorm2d(nn.Module):
         self.bias = nn.Parameter(torch.zeros(num_channels))
         self.eps = eps
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        u = x.mean(1, keepdim=True)
-        s = (x - u).pow(2).mean(1, keepdim=True)
-        x = (x - u) / torch.sqrt(s + self.eps)
-        x = self.weight[:, None, None] * x + self.bias[:, None, None]
-        return x
+    # default implementation
+    #def forward(self, x: torch.Tensor) -> torch.Tensor:
+    #    u = x.mean(1, keepdim=True)
+    #    s = (x - u).pow(2).mean(1, keepdim=True)
+    #    x = (x - u) / torch.sqrt(s + self.eps)
+    #    x = self.weight[:, None, None] * x + self.bias[:, None, None]
+    #    return x
 
+    # for MINCUT
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+       # Turn into `NHWC` if required or any other specific format
+       x = x.permute(0, 2, 3, 1)  # Optional based on requirements
+       # Operations here depend on whether Channel is leading or at the end
+       u = x.mean(3, keepdim=True)
+       s = (x - u).pow(2).mean(3, keepdim=True)
+       s = s + self.eps
+       x = (x - u) / torch.sqrt(s)
+       x = self.weight * x + self.bias
+       # Revert back `NCHW`
+       x = x.permute(0, 3, 1, 2)  # If you converted earlier
+       return x
 
 def sample_box_points(
     masks: torch.Tensor,

--- a/sam2/modeling/sam2_utils.py
+++ b/sam2/modeling/sam2_utils.py
@@ -145,13 +145,19 @@ class LayerNorm2d(nn.Module):
         self.bias = nn.Parameter(torch.zeros(num_channels))
         self.eps = eps
 
-    # default implementation
-    #def forward(self, x: torch.Tensor) -> torch.Tensor:
-    #    u = x.mean(1, keepdim=True)
-    #    s = (x - u).pow(2).mean(1, keepdim=True)
-    #    x = (x - u) / torch.sqrt(s + self.eps)
-    #    x = self.weight[:, None, None] * x + self.bias[:, None, None]
-    #    return x
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        u = x.mean(1, keepdim=True)
+        s = (x - u).pow(2).mean(1, keepdim=True)
+        x = (x - u) / torch.sqrt(s + self.eps)
+        x = self.weight[:, None, None] * x + self.bias[:, None, None]
+        return x
+
+class LayerNorm2dNHWC(nn.Module):
+    def __init__(self, num_channels: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(num_channels))
+        self.bias = nn.Parameter(torch.zeros(num_channels))
+        self.eps = eps
 
     # for MINCUT
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/sam2/modeling/sam2_utils.py
+++ b/sam2/modeling/sam2_utils.py
@@ -177,6 +177,29 @@ class LayerNorm2dWithNN(nn.Module):
         x = x.permute(0, 3, 1, 2)
         return x
 
+class LayerNorm2dWithNN3Dim(nn.Module):
+    def __init__(self, num_channels: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.num_channels = num_channels
+        # Set initial weights and biases similar to the original implementation
+        self.weight = nn.Parameter(torch.ones(num_channels))
+        self.bias = nn.Parameter(torch.zeros(num_channels))
+        self.eps = eps
+        self.load_weight = False
+
+    def load_weights_from_old_model(self):
+        self.layer_norm = nn.LayerNorm(normalized_shape=self.num_channels, eps=self.eps, elementwise_affine=True)
+        self.layer_norm.weight.data =  self.weight
+        self.layer_norm.bias.data = self.bias
+        self.load_weight = True
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        assert(self.load_weight)
+        x = x.permute(1, 2, 0)
+        x = self.layer_norm(x)
+        x = x.permute(2, 0, 1)
+        return x
+
 def sample_box_points(
     masks: torch.Tensor,
     noise: float = 0.1,  # SAM default

--- a/sam2/modeling/sam2_utils.py
+++ b/sam2/modeling/sam2_utils.py
@@ -172,10 +172,9 @@ class LayerNorm2dWithNN(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         assert(self.load_weight)
-        orig_shape = x.shape
-        x = x.view(orig_shape[0], orig_shape[1], -1).transpose(1, 2)  # (N, C, H*W) -> (N, H*W, C)
+        x = x.permute(0, 2, 3, 1)
         x = self.layer_norm(x)
-        x = x.transpose(1, 2).view(orig_shape)  # (N, H*W, C) -> (N, C, H, W)
+        x = x.permute(0, 3, 1, 2)
         return x
 
 def sample_box_points(

--- a/sam2/modeling/sam2_utils.py
+++ b/sam2/modeling/sam2_utils.py
@@ -152,26 +152,31 @@ class LayerNorm2d(nn.Module):
         x = self.weight[:, None, None] * x + self.bias[:, None, None]
         return x
 
-class LayerNorm2dNHWC(nn.Module):
+# Use official nn.layernorm
+# Need to convert original weight to nn.layernorm weight
+class LayerNorm2dWithNN(nn.Module):
     def __init__(self, num_channels: int, eps: float = 1e-6) -> None:
         super().__init__()
+        self.num_channels = num_channels
+        # Set initial weights and biases similar to the original implementation
         self.weight = nn.Parameter(torch.ones(num_channels))
         self.bias = nn.Parameter(torch.zeros(num_channels))
         self.eps = eps
+        self.load_weight = False
 
-    # for AIEDGETORCH_LAYOUT_OPTIMIZE_PARTITIONER=MINCUT
+    def load_weights_from_old_model(self):
+        self.layer_norm = nn.LayerNorm(normalized_shape=self.num_channels, eps=self.eps, elementwise_affine=True)
+        self.layer_norm.weight.data =  self.weight
+        self.layer_norm.bias.data = self.bias
+        self.load_weight = True
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-       # Turn into `NHWC` if required or any other specific format
-       x = x.permute(0, 2, 3, 1)  # Optional based on requirements
-       # Operations here depend on whether Channel is leading or at the end
-       u = x.mean(3, keepdim=True)
-       s = (x - u).pow(2).mean(3, keepdim=True)
-       s = s + self.eps
-       x = (x - u) / torch.sqrt(s)
-       x = self.weight * x + self.bias
-       # Revert back `NCHW`
-       x = x.permute(0, 3, 1, 2)  # If you converted earlier
-       return x
+        assert(self.load_weight)
+        orig_shape = x.shape
+        x = x.view(orig_shape[0], orig_shape[1], -1).transpose(1, 2)  # (N, C, H*W) -> (N, H*W, C)
+        x = self.layer_norm(x)
+        x = x.transpose(1, 2).view(orig_shape)  # (N, H*W, C) -> (N, C, H, W)
+        return x
 
 def sample_box_points(
     masks: torch.Tensor,

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -746,8 +746,6 @@ class SAM2ImagePredictor:
                 )
                 with_quantizer.export("model/mask_decoder_"+model_id+".int8.tflite")
 
-                edge_model = model
-
         if import_from_tflite:
             batched_mode_np = np.zeros((1), dtype=bool)
             if batched_mode:

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -202,9 +202,9 @@ class SAM2ImagePredictor:
                 tfl_converter_flags = {'target_spec': {'supported_ops': [tf.lite.OpsSet.TFLITE_BUILTINS]}}
                 edge_model = ai_edge_torch.convert(self.model, sample_inputs, _ai_edge_converter_flags=tfl_converter_flags)
                 edge_model.export("model/image_encoder_"+model_id+".tflite")
-
+            
             if tflite_int8:
-                if False:
+                if tflite_int8 == "mixed":
                     # torch quantization
                     from ai_edge_torch.quantize import pt2e_quantizer
                     from ai_edge_torch.quantize import quant_config
@@ -232,7 +232,7 @@ class SAM2ImagePredictor:
                         sample_inputs,
                         quant_config=quant_config.QuantConfig(pt2e_quantizer=quantizer),
                     )
-                    with_quantizer.export("model/image_encoder_"+model_id+".int8.tflite")
+                    with_quantizer.export("model/image_encoder_"+model_id+".mixed.tflite")
                 else:
                     # tensorflow quantization
                     import glob
@@ -264,7 +264,7 @@ class SAM2ImagePredictor:
             if self.image_encoder_tflite == None:
                 int8_id = ""
                 if tflite_int8:
-                    int8_id = ".int8"
+                    int8_id = "." + tflite_int8
                 if import_from_tflite == "ailia_tflite":
                     import ailia_tflite
                     self.image_encoder_tflite = ailia_tflite.Interpreter(model_path="model/image_encoder_"+model_id+int8_id+".tflite", memory_mode=ailia_tflite.AILIA_TFLITE_MEMORY_MODE_REDUCE_INTERSTAGE, flags=ailia_tflite.AILIA_TFLITE_FLAG_DYNAMIC_QUANT)
@@ -684,7 +684,7 @@ class SAM2ImagePredictor:
                         sample_inputs,
                         quant_config=quant_config.QuantConfig(pt2e_quantizer=quantizer),
                     )
-                    with_quantizer.export("model/prompt_encoder_"+model_id+".int8.tflite")
+                    with_quantizer.export("model/prompt_encoder_"+model_id+".mixed.tflite")
                 else:
                     # tensorflow quantization
                     import glob
@@ -725,7 +725,7 @@ class SAM2ImagePredictor:
             if self.prompt_encoder_tflite == None:
                 int8_id = ""
                 if tflite_int8_prompt_encoder:
-                    int8_id = ".int8"
+                    int8_id = "." + tflite_int8_prompt_encoder
                 if import_from_tflite == "ailia_tflite":
                     import ailia_tflite
                     self.prompt_encoder_tflite = ailia_tflite.Interpreter(model_path="model/prompt_encoder_"+model_id+int8_id+".tflite", memory_mode=ailia_tflite.AILIA_TFLITE_MEMORY_MODE_REDUCE_INTERSTAGE, flags=ailia_tflite.AILIA_TFLITE_FLAG_DYNAMIC_QUANT)
@@ -839,7 +839,7 @@ class SAM2ImagePredictor:
                 edge_model.export("model/mask_decoder_"+model_id+".tflite")
 
             if tflite_int8:
-                if False:
+                if tflite_int8 == "mixed":
                     # torch quantization
                     from ai_edge_torch.quantize import pt2e_quantizer
                     from ai_edge_torch.quantize import quant_config
@@ -874,7 +874,7 @@ class SAM2ImagePredictor:
                         sample_inputs,
                         quant_config=quant_config.QuantConfig(pt2e_quantizer=quantizer),
                     )
-                    with_quantizer.export("model/mask_decoder_"+model_id+".int8.tflite")
+                    with_quantizer.export("model/mask_decoder_"+model_id+".mixed.tflite")
                 else:
                     # tensorflow quantization
                     import glob
@@ -927,7 +927,7 @@ class SAM2ImagePredictor:
             if self.mask_decoder_tflite == None:
                 int8_id = ""
                 if tflite_int8:
-                    int8_id = ".int8"
+                    int8_id = "." + tflite_int8
                 if import_from_tflite == "ailia_tflite":
                     import ailia_tflite
                     self.mask_decoder_tflite  = ailia_tflite.Interpreter(model_path="model/mask_decoder_"+model_id+int8_id+".tflite", memory_mode=ailia_tflite.AILIA_TFLITE_MEMORY_MODE_REDUCE_INTERSTAGE, flags=ailia_tflite.AILIA_TFLITE_FLAG_DYNAMIC_QUANT)

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -202,7 +202,7 @@ class SAM2ImagePredictor:
                 from torch.ao.quantization import quantize_pt2e
 
                 quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
-                    pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False)
+                    pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
                 )
                 model = torch._export.capture_pre_autograd_graph(self.model, sample_inputs)
                 model = quantize_pt2e.prepare_pt2e(model, quantizer)
@@ -216,13 +216,13 @@ class SAM2ImagePredictor:
                     quant_config=quant_config.QuantConfig(pt2e_quantizer=quantizer),
                     _ai_edge_converter_flags=tfl_converter_flags
                 )
-                with_quantizer.export("model/image_encoder_"+model_id+"_int8.tflite")
+                with_quantizer.export("model/image_encoder_"+model_id+".int8.tflite")
 
         if import_from_tflite:
             if self.image_encoder_tflite == None:
                 int8_id = ""
                 if tflite_int8:
-                    int8_id = "_int8"
+                    int8_id = ".int8"
                 if import_from_tflite == "ailia_tflite":
                     import ailia_tflite
                     self.image_encoder_tflite = ailia_tflite.Interpreter(model_path="model/image_encoder_"+model_id+int8_id+".tflite", memory_mode=ailia_tflite.AILIA_TFLITE_MEMORY_MODE_REDUCE_INTERSTAGE, flags=ailia_tflite.AILIA_TFLITE_FLAG_DYNAMIC_QUANT)

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -777,13 +777,13 @@ class SAM2ImagePredictor:
             batched_mode = False
 
             if tflite_int8:
-                self.mask_decoder_tflite.set_tensor(self.format_input_tensor(self._features["image_embed"][img_idx].unsqueeze(0).numpy(), input_details, 3))
-                self.mask_decoder_tflite.set_tensor(self.format_input_tensor(dense_pe, input_details, 6))
-                self.mask_decoder_tflite.set_tensor(self.format_input_tensor(sparse_embeddings, input_details, 1))
-                self.mask_decoder_tflite.set_tensor(self.format_input_tensor(dense_embeddings, input_details, 2))
-                self.mask_decoder_tflite.set_tensor(self.format_input_tensor(batched_mode, input_details, 5))
-                self.mask_decoder_tflite.set_tensor(self.format_input_tensor(high_res_features[0].numpy(), input_details, 0))
-                self.mask_decoder_tflite.set_tensor(self.format_input_tensor(high_res_features[1].numpy(), input_details, 4))
+                self.mask_decoder_tflite.set_tensor(input_details[3]["index"], self.format_input_tensor(self._features["image_embed"][img_idx].unsqueeze(0).numpy(), input_details, 3))
+                self.mask_decoder_tflite.set_tensor(input_details[6]["index"], self.format_input_tensor(dense_pe.numpy(), input_details, 6))
+                self.mask_decoder_tflite.set_tensor(input_details[1]["index"], self.format_input_tensor(sparse_embeddings.numpy(), input_details, 1))
+                self.mask_decoder_tflite.set_tensor(input_details[2]["index"], self.format_input_tensor(dense_embeddings.numpy(), input_details, 2))
+                self.mask_decoder_tflite.set_tensor(input_details[5]["index"], batched_mode)
+                self.mask_decoder_tflite.set_tensor(input_details[0]["index"], self.format_input_tensor(high_res_features[0].numpy(), input_details, 0))
+                self.mask_decoder_tflite.set_tensor(input_details[4]["index"], self.format_input_tensor(high_res_features[1].numpy(), input_details, 4))
                 self.mask_decoder_tflite.invoke()
 
                 masks = self.get_output_tensor(self.mask_decoder_tflite, output_details, 2)

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -646,7 +646,6 @@ class SAM2ImagePredictor:
             dense_pe = torch.Tensor(dense_pe)
 
         tflite_int8_prompt_encoder = tflite_int8
-        #tflite_int8_prompt_encoder = False # 精度不足
 
         if export_to_tflite:
             import ai_edge_torch
@@ -710,6 +709,10 @@ class SAM2ImagePredictor:
                     )
 
                     tfl_fullint_model.export("model/prompt_encoder_"+model_id+".int8.tflite")
+
+        if tflite_int8:
+            tflite_int8_prompt_encoder = False # 精度不足なのでFloatモデルで推論する
+            print("Warning : prompt encoder will use float model for better accuracy.")
 
         if import_from_tflite:
             if self.prompt_encoder_tflite == None:

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -732,7 +732,7 @@ class SAM2ImagePredictor:
                 from torch.ao.quantization import quantize_pt2e
 
                 quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
-                    pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
+                    pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=False) # Trueだとエラー
                 )
                 model = torch._export.capture_pre_autograd_graph(self.model.sam_mask_decoder, sample_inputs)
                 model = quantize_pt2e.prepare_pt2e(model, quantizer)

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -747,10 +747,10 @@ class SAM2ImagePredictor:
                 dense_embeddings = self.get_output_tensor(self.prompt_encoder_tflite, output_details, 0)
                 dense_pe = self.get_output_tensor(self.prompt_encoder_tflite, output_details, 2)
             else:
-                self.prompt_encoder_tflite.set_tensor(input_details[2]["index"], concat_points[0])
-                self.prompt_encoder_tflite.set_tensor(input_details[3]["index"], concat_points[1])
-                self.prompt_encoder_tflite.set_tensor(input_details[0]["index"], mask_input_dummy)
-                self.prompt_encoder_tflite.set_tensor(input_details[1]["index"], masks_enable)
+                self.prompt_encoder_tflite.set_tensor(input_details[2]["index"], concat_points[0].numpy())
+                self.prompt_encoder_tflite.set_tensor(input_details[3]["index"], concat_points[1].numpy())
+                self.prompt_encoder_tflite.set_tensor(input_details[0]["index"], mask_input_dummy.numpy())
+                self.prompt_encoder_tflite.set_tensor(input_details[1]["index"], masks_enable.numpy())
                 self.prompt_encoder_tflite.invoke()
 
                 sparse_embeddings = self.prompt_encoder_tflite.get_tensor(output_details[1]["index"])
@@ -940,9 +940,9 @@ class SAM2ImagePredictor:
                 object_score_logits = self.get_output_tensor(self.mask_decoder_tflite, output_details, 1)
             else:
                 self.mask_decoder_tflite.set_tensor(input_details[3]["index"], self._features["image_embed"][img_idx].unsqueeze(0).numpy())
-                self.mask_decoder_tflite.set_tensor(input_details[6]["index"], dense_pe)
-                self.mask_decoder_tflite.set_tensor(input_details[1]["index"], sparse_embeddings)
-                self.mask_decoder_tflite.set_tensor(input_details[2]["index"], dense_embeddings)
+                self.mask_decoder_tflite.set_tensor(input_details[6]["index"], dense_pe.numpy())
+                self.mask_decoder_tflite.set_tensor(input_details[1]["index"], sparse_embeddings.numpy())
+                self.mask_decoder_tflite.set_tensor(input_details[2]["index"], dense_embeddings.numpy())
                 self.mask_decoder_tflite.set_tensor(input_details[5]["index"], batched_mode)
                 self.mask_decoder_tflite.set_tensor(input_details[0]["index"], high_res_features[0].numpy())
                 self.mask_decoder_tflite.set_tensor(input_details[4]["index"], high_res_features[1].numpy())

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -628,7 +628,7 @@ class SAM2ImagePredictor:
             padding_length= max_sparse_embedding_length - 1
             concat_points_pad = (
                 torch.zeros(concat_points[0].shape[0], padding_length, concat_points[0].shape[2]),
-                torch.zeros(concat_points[0].shape[0], padding_length)
+                -torch.ones(concat_points[0].shape[0], padding_length)
             )
             concat_points_pad[0][:, 0:concat_points[0].shape[1], :] = concat_points[0]
             concat_points_pad[1][:, 0:concat_points[1].shape[1]] = concat_points[1]

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -628,6 +628,8 @@ class SAM2ImagePredictor:
         else:
             mask_input_dummy = mask_input
             masks_enable = torch.tensor([1], dtype=torch.int)
+        
+        self.model.sam_prompt_encoder.generate_dense_pe()
 
         if export_to_onnx:
             #print("concat_points", concat_points.shape)
@@ -666,7 +668,6 @@ class SAM2ImagePredictor:
             if tflite_int8_prompt_encoder:
                 if tflite_int8 == "mixed":
                     # torch quantization
-                    # labelがint64で量子化できないため、floatにannotateして扱う
                     from ai_edge_torch.quantize import pt2e_quantizer
                     from ai_edge_torch.quantize import quant_config
                     from torch.ao.quantization import quantize_pt2e
@@ -690,6 +691,7 @@ class SAM2ImagePredictor:
                                 #    print(n.meta["quantization_annotation"])
 
                                 if n.target in [torch.ops.aten.cat.default]:
+                                    # labelがint64で量子化できないため、floatにannotateして扱う
                                     if "quantization_annotation" in n.meta:
                                         #print(str(n.args[0][0]))
                                         if str(n.args[0][0]) == "arg1_1":
@@ -708,6 +710,7 @@ class SAM2ImagePredictor:
                                             #n.meta["quantization_annotation"].output_qspec = int_spec
 
                                 if n.target in [torch.ops.aten.gelu.default]:
+                                    # geluをint8で実行
                                     input_qspec_map = {}
                                     input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
                                     n.meta["quantization_annotation"] = QuantizationAnnotation(

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -960,6 +960,7 @@ class SAM2ImagePredictor:
 
                             for n in model.graph.nodes:
                                 if n.target in [torch.ops.aten.conv_transpose2d.input]:
+                                if n.target in [torch.ops.aten.conv_transpose2d.input, torch.ops.aten.linear.default]:
                                     input_qspec_map = {}
 
                                     input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
@@ -982,6 +983,23 @@ class SAM2ImagePredictor:
                                         output_qspec=get_output_act_qspec(quantization_config),
                                         _annotated=True,
                                     )
+
+                            if True:
+                                # 出力ノードをint8にする
+                                target_node = None
+                                for n in model.graph.nodes:
+                                    if str(n.target) == "output":
+                                        target_node = n.args[0][0]
+
+                                for n in model.graph.nodes:
+                                    if n == target_node:
+                                        input_qspec_map = {}
+                                        input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+                                        n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                            input_qspec_map=input_qspec_map,
+                                            output_qspec=get_output_act_qspec(quantization_config),
+                                            _annotated=True,
+                                        )
 
                             return model
 

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -1098,6 +1098,19 @@ class SAM2ImagePredictor:
             low_res_masks, iou_predictions, _, _  = self.model.sam_mask_decoder.forward_postprocess(masks, iou_pred, sam_tokens_out, object_score_logits, multimask_output)
 
         if not import_from_onnx and not import_from_tflite:
+            convert_to_static_shape = True #export_to_tflite or import_from_tflite or self.calibration
+            if convert_to_static_shape:
+                max_num_sparse_embeddings = 32 #sparse_embeddings.shape[1]
+                sparse_embeddings_pad = torch.zeros(sparse_embeddings.shape[0], max_num_sparse_embeddings, sparse_embeddings.shape[2])
+                sparse_embeddings_pad[:,:sparse_embeddings.shape[1],:] = sparse_embeddings
+                attn_masks = torch.zeros((sparse_embeddings_pad.shape[0], sparse_embeddings_pad.shape[1]), dtype=torch.bool)
+                attn_masks[:,:sparse_embeddings.shape[1]] = True
+                print(sparse_embeddings.shape)
+                print(attn_masks)
+                sparse_embeddings = sparse_embeddings_pad
+            else:
+                attn_masks = torch.ones((sparse_embeddings.shape[0], sparse_embeddings.shape[1]), dtype=torch.bool)
+
             self.model.sam_mask_decoder.forward = self.model.sam_mask_decoder.forward_normal
             low_res_masks, iou_predictions, _, _  = self.model.sam_mask_decoder(
                 image_embeddings=self._features["image_embed"][img_idx].unsqueeze(0),
@@ -1108,6 +1121,7 @@ class SAM2ImagePredictor:
                 repeat_image=batched_mode,
                 high_res_features1=high_res_features[0],
                 high_res_features2=high_res_features[1],
+                attn_masks=attn_masks
             )
 
             if self.calibration:

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -606,8 +606,9 @@ class SAM2ImagePredictor:
             concat_points = None
 
         # Convert to static shape using attn_masks
-        convert_to_static_shape = True #export_to_tflite or import_from_tflite or self.calibration
+        convert_to_static_shape = export_to_tflite or import_from_tflite or self.calibration
         original_sparse_embedding_length = concat_points[0].shape[1] + 1
+        max_sparse_embedding_length = 32
 
         # Embed prompts
         if boxes is not None:
@@ -624,7 +625,7 @@ class SAM2ImagePredictor:
                 concat_points = (box_coords, box_labels)
 
         if convert_to_static_shape:
-            padding_length= 16
+            padding_length= max_sparse_embedding_length - 1
             concat_points_pad = (
                 torch.zeros(concat_points[0].shape[0], padding_length, concat_points[0].shape[2]),
                 torch.zeros(concat_points[0].shape[0], padding_length)
@@ -875,6 +876,17 @@ class SAM2ImagePredictor:
         if convert_to_static_shape:
             sparse_embeddings = sparse_embeddings[:, :original_sparse_embedding_length, :]
 
+        # Prepare attn_mask for mask decoder
+        if convert_to_static_shape:
+            max_num_sparse_embeddings = max_sparse_embedding_length
+            sparse_embeddings_pad = torch.zeros(sparse_embeddings.shape[0], max_num_sparse_embeddings, sparse_embeddings.shape[2])
+            sparse_embeddings_pad[:,:sparse_embeddings.shape[1],:] = sparse_embeddings
+            attn_masks = torch.zeros((sparse_embeddings_pad.shape[0], sparse_embeddings_pad.shape[1]), dtype=torch.bool)
+            attn_masks[:,:sparse_embeddings.shape[1]] = True
+            sparse_embeddings = sparse_embeddings_pad
+        else:
+            attn_masks = torch.ones((sparse_embeddings.shape[0], sparse_embeddings.shape[1]), dtype=torch.bool)
+
         # Predict masks
         batched_mode = (
             concat_points is not None and concat_points[0].shape[0] > 1
@@ -890,12 +902,13 @@ class SAM2ImagePredictor:
         if export_to_onnx:
             self.model.sam_mask_decoder.forward = self.model.sam_mask_decoder.forward_masks # multimask_outputが定数になってしまうので分離
             torch.onnx.export(
-                self.model.sam_mask_decoder, (self._features["image_embed"][img_idx].unsqueeze(0), dense_pe, sparse_embeddings, dense_embeddings, batched_mode, high_res_features[0], high_res_features[1]),
+                self.model.sam_mask_decoder, (self._features["image_embed"][img_idx].unsqueeze(0), dense_pe, sparse_embeddings, dense_embeddings, batched_mode, high_res_features[0], high_res_features[1], attn_masks),
                 'model/mask_decoder_'+model_id+'.onnx',
-                input_names=["image_embeddings", "image_pe", "sparse_prompt_embeddings", "dense_prompt_embeddings", "repeat_image", "high_res_features1", "high_res_features2"],
+                input_names=["image_embeddings", "image_pe", "sparse_prompt_embeddings", "dense_prompt_embeddings", "repeat_image", "high_res_features1", "high_res_features2", "attn_masks"],
                 output_names=["masks", "iou_pred", "sam_tokens_out", "object_score_logits"],
                 dynamic_axes={
                     'sparse_prompt_embeddings': {1: 'n'},
+                    'attn_masks': {1: 'n'},
                 },
                 verbose=False, opset_version=17
             )
@@ -909,7 +922,8 @@ class SAM2ImagePredictor:
                 "sparse_prompt_embeddings": sparse_embeddings.numpy(),
                 "dense_prompt_embeddings": dense_embeddings.numpy(),
                 "high_res_features1":high_res_features[0].numpy(),
-                "high_res_features2":high_res_features[1].numpy()})
+                "high_res_features2":high_res_features[1].numpy(),
+                "attn_masks": attn_masks.numpy()})
             masks = torch.Tensor(masks)
             iou_pred = torch.Tensor(iou_pred)
             sam_tokens_out = torch.Tensor(sam_tokens_out)
@@ -918,7 +932,7 @@ class SAM2ImagePredictor:
 
         if export_to_tflite:
             self.model.sam_mask_decoder.forward = self.model.sam_mask_decoder.forward_masks
-            sample_inputs = (self._features["image_embed"][img_idx].unsqueeze(0), dense_pe, sparse_embeddings, dense_embeddings, batched_mode, high_res_features[0], high_res_features[1])
+            sample_inputs = (self._features["image_embed"][img_idx].unsqueeze(0), dense_pe, sparse_embeddings, dense_embeddings, batched_mode, high_res_features[0], high_res_features[1], attn_masks)
 
             if not tflite_int8:
                 import ai_edge_torch
@@ -996,7 +1010,8 @@ class SAM2ImagePredictor:
                         data4 = batched_mode
                         data5 = torch.tensor(npz["arr_4"])
                         data6 = torch.tensor(npz["arr_5"])
-                        model(data0, data1, data2, data3, data4, data5, data6)
+                        data7 = torch.tensor(npz["arr_6"])
+                        model(data0, data1, data2, data3, data4, data5, data6, data7)
 
                     model = quantize_pt2e.convert_pt2e(model, fold_quantize=False)
 
@@ -1033,8 +1048,9 @@ class SAM2ImagePredictor:
                             data5[0] = batched_mode
                             data0 = npz["arr_4"]
                             data4 = npz["arr_5"]
+                            data7 = npz["arr_6"]
 
-                            yield [data0, data1, data2, data3, data4, data5, data6]
+                            yield [data0, data1, data2, data3, data4, data5, data6, data7]
                     
                     tfl_converter_flags = {
                         'optimizations': [tf.lite.Optimize.DEFAULT],
@@ -1067,10 +1083,6 @@ class SAM2ImagePredictor:
                     self.mask_decoder_tflite  = tf.lite.Interpreter(model_path="model/mask_decoder_"+model_id+int8_id+".tflite")
                 self.mask_decoder_tflite.allocate_tensors()
                 input_details = self.mask_decoder_tflite.get_input_details()
-                #self.mask_decoder_tflite.resize_tensor_input(
-                #    input_details[1]["index"], 
-                #    [1, sparse_embeddings.shape[1], 256]
-                #)
                 self.mask_decoder_tflite.allocate_tensors()
 
             input_details = self.mask_decoder_tflite.get_input_details()
@@ -1086,6 +1098,7 @@ class SAM2ImagePredictor:
                 self.mask_decoder_tflite.set_tensor(input_details[5]["index"], batched_mode)
                 self.mask_decoder_tflite.set_tensor(input_details[0]["index"], self.format_input_tensor(high_res_features[0].numpy(), input_details, 0))
                 self.mask_decoder_tflite.set_tensor(input_details[4]["index"], self.format_input_tensor(high_res_features[1].numpy(), input_details, 4))
+                self.mask_decoder_tflite.set_tensor(input_details[7]["index"], self.format_input_tensor(attn_masks.numpy(), input_details, 7))
                 self.mask_decoder_tflite.invoke()
 
                 masks = self.get_output_tensor(self.mask_decoder_tflite, output_details, 2)
@@ -1100,6 +1113,7 @@ class SAM2ImagePredictor:
                 self.mask_decoder_tflite.set_tensor(input_details[5]["index"], batched_mode)
                 self.mask_decoder_tflite.set_tensor(input_details[0]["index"], high_res_features[0].numpy())
                 self.mask_decoder_tflite.set_tensor(input_details[4]["index"], high_res_features[1].numpy())
+                self.mask_decoder_tflite.set_tensor(input_details[7]["index"], attn_masks.numpy())
                 self.mask_decoder_tflite.invoke()
 
                 masks = self.mask_decoder_tflite.get_tensor(output_details[2]["index"])
@@ -1115,16 +1129,6 @@ class SAM2ImagePredictor:
             low_res_masks, iou_predictions, _, _  = self.model.sam_mask_decoder.forward_postprocess(masks, iou_pred, sam_tokens_out, object_score_logits, multimask_output)
 
         if not import_from_onnx and not import_from_tflite:
-            if convert_to_static_shape:
-                max_num_sparse_embeddings = 32 #sparse_embeddings.shape[1]
-                sparse_embeddings_pad = torch.zeros(sparse_embeddings.shape[0], max_num_sparse_embeddings, sparse_embeddings.shape[2])
-                sparse_embeddings_pad[:,:sparse_embeddings.shape[1],:] = sparse_embeddings
-                attn_masks = torch.zeros((sparse_embeddings_pad.shape[0], sparse_embeddings_pad.shape[1]), dtype=torch.bool)
-                attn_masks[:,:sparse_embeddings.shape[1]] = True
-                sparse_embeddings = sparse_embeddings_pad
-            else:
-                attn_masks = torch.ones((sparse_embeddings.shape[0], sparse_embeddings.shape[1]), dtype=torch.bool)
-
             self.model.sam_mask_decoder.forward = self.model.sam_mask_decoder.forward_normal
             low_res_masks, iou_predictions, _, _  = self.model.sam_mask_decoder(
                 image_embeddings=self._features["image_embed"][img_idx].unsqueeze(0),
@@ -1147,7 +1151,8 @@ class SAM2ImagePredictor:
                     sparse_embeddings.numpy(),
                     dense_embeddings.numpy(),
                     high_res_features[0].numpy(),
-                    high_res_features[1].numpy()
+                    high_res_features[1].numpy(),
+                    attn_masks.numpy()
                 )
                 self.calibration_cnt_mask_decoder = self.calibration_cnt_mask_decoder + 1
 

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -873,6 +873,15 @@ class SAM2ImagePredictor:
                                         _annotated=True,
                                     )
 
+                                if n.target in [torch.ops.aten.gelu.default]:
+                                    input_qspec_map = {}
+                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                        input_qspec_map=input_qspec_map,
+                                        output_qspec=get_output_act_qspec(quantization_config),
+                                        _annotated=True,
+                                    )
+
                             return model
 
                     if False:

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -709,10 +709,11 @@ class SAM2ImagePredictor:
 
                                             #n.meta["quantization_annotation"].output_qspec = int_spec
 
-                                if n.target in [torch.ops.aten.gelu.default]:
-                                    # geluをint8で実行
+                                if n.target in [torch.ops.aten.gelu.default, torch.ops.aten.sin.default, torch.ops.aten.cos.default, torch.ops.aten.div_.Tensor]:
+                                    # geluとdivをint8で実行
                                     input_qspec_map = {}
-                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+                                    for i in range(len(n.args)):
+                                        input_qspec_map[n.args[i]] = get_input_act_qspec(quantization_config)
                                     n.meta["quantization_annotation"] = QuantizationAnnotation(
                                         input_qspec_map=input_qspec_map,
                                         output_qspec=get_output_act_qspec(quantization_config),

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -848,126 +848,22 @@ class SAM2ImagePredictor:
                     from torch.ao.quantization import quantize_pt2e
 
                     # quantize transpose_conv
-                    from ai_edge_torch.quantize.pt2e_quantizer_utils import QuantizationConfig, register_annotator, get_input_act_qspec, get_weight_qspec, get_bias_qspec, _is_annotated, get_output_act_qspec, _mark_nodes_as_annotated
-                    from typing import Callable, Dict, List, Optional
+                    from ai_edge_torch.quantize.pt2e_quantizer_utils import get_input_act_qspec, get_weight_qspec, get_bias_qspec, get_output_act_qspec
                     from torch.ao.quantization.quantizer import QuantizationAnnotation
-                    from torch.fx import Node
-                    from ai_edge_torch.quantize.pt2e_quantizer_utils import propagate_annotation
-                    from ai_edge_torch.quantize.pt2e_quantizer_utils import OperatorPatternType
-                    import torch.nn.functional as F
-                    import copy
-
-                    #@register_annotator("transpose_conv")
-                    def _annotate_transpose_conv(
-                        gm: torch.fx.GraphModule,
-                        quantization_config: Optional[QuantizationConfig],
-                        filter_fn: Optional[Callable[[Node], bool]] = None,
-                    ) -> Optional[List[List[Node]]]:
-                        annotated_partitions = []
-                        for n in gm.graph.nodes:
-                            print(n.target)
-                            if n.op != "call_function" or n.target not in [
-                                torch.ops.aten.conv_transpose2d, torch.ops.aten.conv_transpose2d.input,
-                            ]:
-                                continue
-                            print("# transpose_conv")
-                            conv_node = n
-                            print(conv_node.args)
-
-                            input_qspec_map = {}
-                            input_act = conv_node.args[0]
-                            assert isinstance(input_act, Node)
-                            input_qspec_map[input_act] = get_input_act_qspec(quantization_config)
-                            
-                            weight = conv_node.args[1]
-                            assert isinstance(weight, Node)
-                            input_qspec_map[weight] = get_weight_qspec(quantization_config)
-
-                            bias = conv_node.args[2]
-                            assert isinstance(bias, Node)
-                            input_qspec_map[bias] = get_bias_qspec(quantization_config)
-                             
-                            # adding weight node to the partition as well
-                            partition = [conv_node, conv_node.args[1], conv_node.args[2]]
-
-                            if _is_annotated(partition):
-                                continue
-
-                            if filter_fn and any(not filter_fn(n) for n in partition):
-                                continue
-
-                            #bias = conv_node.args[2] if len(conv_node.args) > 2 else None
-                            #if isinstance(bias, Node):
-                            #    print(" bias enable")
-                            #    input_qspec_map[bias] = get_bias_qspec(quantization_config)
-                            #    partition.append(bias)
-
-                            #shape = conv_node.args[3] if len(conv_node.args) > 3 else None
-                            #if isinstance(shape, Node):
-                            #    print(" shape enable")
-                            #    input_qspec_map[shape] = get_bias_qspec(quantization_config)
-                            #    partition.append(shape)
-
-                            #if _is_annotated(partition):
-                            #    print(" not annotated")
-                            #    continue
-
-                            #if filter_fn and any(not filter_fn(n) for n in partition):
-                            #    print(" not in filter")
-                            #    continue
-
-                            #print(input_qspec_map)
-                            #print(get_output_act_qspec(quantization_config))
-
-
-                            conv_node.meta["quantization_annotation"] = QuantizationAnnotation(
-                                input_qspec_map=input_qspec_map,
-                                output_qspec=get_output_act_qspec(quantization_config),
-                                _annotated=True,
-                            )
-                            _mark_nodes_as_annotated(partition)
-                            annotated_partitions.append(partition)
-                        return annotated_partitions
 
                     quantization_config = pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=False)
 
                     class PT2EQuantizer2(pt2e_quantizer.PT2EQuantizer):
-                        # static quantization ops (both PTQ and QAT)
-                        STATIC_OPS = [
-                            "linear",
-                            "addmm",
-                            "conv_relu",
-                            "conv",
-                            "adaptive_avg_pool2d",
-                            "gru_io_only",
-                            "max_pool2d",
-                            "add_relu",
-                            "add",
-                            "mul_relu",
-                            "mul",
-                            "cat",
-                            "fixed_qparams",
-                            #"transpose_conv", # added
-                        ]
-
                         def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
                             super().annotate(model)
-                            
-                            #model = self._annotate_for_static_quantization_config(model)
 
                             for n in model.graph.nodes:
-                                print(n.target, n.meta)
-                                
                                 if n.target in [torch.ops.aten.conv_transpose2d.input]:
-                                    #print(n.target, n.meta)
-
-                                    # StableHLOの内部でweightがtransposeされるためにqdqの変換がうまくいかず、完全にint8にはできない
-                                    # ただ、layernormの出力のquantizeでパーティションを分割して、dq -> transposeconv -> qとするために、
-                                    # 入力側にはint8の制約をかける
-
                                     input_qspec_map = {}
 
                                     input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+
+                                    # weightにも制約をかけるとうまくint8に変換できなくなるため、inputにだけ制約をかける
                                     #input_qspec_map[n.args[1]] = get_weight_qspec(quantization_config)
                                     #input_qspec_map[n.args[2]] = get_bias_qspec(quantization_config)
 
@@ -977,46 +873,16 @@ class SAM2ImagePredictor:
                                         _annotated=True,
                                     )
 
-                                    print(n.target, n.meta)
-
-                                if False:#n.target in [torch.ops.aten.linear.default]:
-                                    #print(n.target, n.meta)
-
-                                    input_qspec_map = {}
-
-                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
-                                    input_qspec_map[n.args[1]] = get_input_act_qspec(quantization_config)
-
-                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
-                                        input_qspec_map=input_qspec_map,
-                                        output_qspec=get_output_act_qspec(quantization_config),
-                                        _annotated=True,
-                                    )
-
-                                    print(n.target, n.meta)
-
-                                if False:#n.target in [torch.ops.aten.gelu.default]:
-                                    #print(n.target, n.meta)
-
-                                    input_qspec_map = {}
-
-                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
-
-                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
-                                        input_qspec_map=input_qspec_map,
-                                        output_qspec=get_output_act_qspec(quantization_config),
-                                        _annotated=True,
-                                    )
-
-                                    print(n.target, n.meta)
-
-                            #propagate_annotation(model)
-
                             return model
 
-                    quantizer = PT2EQuantizer2().set_global(
-                        quantization_config
-                    )
+                    if False:
+                        quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
+                            quantization_config
+                        )
+                    else:
+                        quantizer = PT2EQuantizer2().set_global(
+                            quantization_config
+                        )
                     model = torch._export.capture_pre_autograd_graph(self.model.sam_mask_decoder, sample_inputs)
                     model = quantize_pt2e.prepare_pt2e(model, quantizer)
 

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -1105,8 +1105,6 @@ class SAM2ImagePredictor:
                 sparse_embeddings_pad[:,:sparse_embeddings.shape[1],:] = sparse_embeddings
                 attn_masks = torch.zeros((sparse_embeddings_pad.shape[0], sparse_embeddings_pad.shape[1]), dtype=torch.bool)
                 attn_masks[:,:sparse_embeddings.shape[1]] = True
-                print(sparse_embeddings.shape)
-                print(attn_masks)
                 sparse_embeddings = sparse_embeddings_pad
             else:
                 attn_masks = torch.ones((sparse_embeddings.shape[0], sparse_embeddings.shape[1]), dtype=torch.bool)

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -605,6 +605,10 @@ class SAM2ImagePredictor:
         else:
             concat_points = None
 
+        # Convert to static shape using attn_masks
+        convert_to_static_shape = True #export_to_tflite or import_from_tflite or self.calibration
+        original_sparse_embedding_length = concat_points[0].shape[1] + 1
+
         # Embed prompts
         if boxes is not None:
             box_coords = boxes.reshape(-1, 2, 2)
@@ -618,6 +622,16 @@ class SAM2ImagePredictor:
                 concat_points = (concat_coords, concat_labels)
             else:
                 concat_points = (box_coords, box_labels)
+
+        if convert_to_static_shape:
+            padding_length= 16
+            concat_points_pad = (
+                torch.zeros(concat_points[0].shape[0], padding_length, concat_points[0].shape[2]),
+                torch.zeros(concat_points[0].shape[0], padding_length)
+            )
+            concat_points_pad[0][:, 0:concat_points[0].shape[1], :] = concat_points[0]
+            concat_points_pad[1][:, 0:concat_points[1].shape[1]] = concat_points[1]
+            concat_points = concat_points_pad
 
         # New data for onnx
         if concat_points is None:
@@ -857,6 +871,9 @@ class SAM2ImagePredictor:
                     masks_enable.numpy()
                 )
                 self.calibration_cnt_prompt_encoder = self.calibration_cnt_prompt_encoder + 1
+
+        if convert_to_static_shape:
+            sparse_embeddings = sparse_embeddings[:, :original_sparse_embedding_length, :]
 
         # Predict masks
         batched_mode = (
@@ -1098,7 +1115,6 @@ class SAM2ImagePredictor:
             low_res_masks, iou_predictions, _, _  = self.model.sam_mask_decoder.forward_postprocess(masks, iou_pred, sam_tokens_out, object_score_logits, multimask_output)
 
         if not import_from_onnx and not import_from_tflite:
-            convert_to_static_shape = True #export_to_tflite or import_from_tflite or self.calibration
             if convert_to_static_shape:
                 max_num_sparse_embeddings = 32 #sparse_embeddings.shape[1]
                 sparse_embeddings_pad = torch.zeros(sparse_embeddings.shape[0], max_num_sparse_embeddings, sparse_embeddings.shape[2])

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -664,19 +664,85 @@ class SAM2ImagePredictor:
                 edge_model.export("model/prompt_encoder_"+model_id+".tflite")
 
             if tflite_int8_prompt_encoder:
-                if False:
+                if tflite_int8 == "mixed":
                     # torch quantization
-                    # labelがint64で量子化できない
+                    # labelがint64で量子化できないため、floatにannotateして扱う
                     from ai_edge_torch.quantize import pt2e_quantizer
                     from ai_edge_torch.quantize import quant_config
                     from torch.ao.quantization import quantize_pt2e
 
-                    quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
-                        pt2e_quantizer.get_symmetric_quantization_config()
-                    )
+                    # torch quantization
+                    from ai_edge_torch.quantize import pt2e_quantizer
+                    from ai_edge_torch.quantize import quant_config
+                    from torch.ao.quantization import quantize_pt2e
+                    from ai_edge_torch.quantize.pt2e_quantizer_utils import get_input_act_qspec, get_output_act_qspec
+                    from torch.ao.quantization.quantizer import QuantizationAnnotation
+
+                    quantization_config = pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
+
+                    class PT2EQuantizerPromptEncoder(pt2e_quantizer.PT2EQuantizer):
+                        def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                            super().annotate(model)
+
+                            for n in model.graph.nodes:
+                                #print(n.target, n.name)
+                                #if "quantization_annotation" in n.meta:
+                                #    print(n.meta["quantization_annotation"])
+
+                                if n.target in [torch.ops.aten.cat.default]:
+                                    if "quantization_annotation" in n.meta:
+                                        #print(str(n.args[0][0]))
+                                        if str(n.args[0][0]) == "arg1_1":
+                                            from torch.ao.quantization.quantizer import QuantizationSpec
+                                            from torch.ao.quantization.observer import PlaceholderObserver
+                                            act_observer_or_fake_quant_ctr = PlaceholderObserver
+
+                                            float_spec = QuantizationSpec(dtype=torch.float32,
+                                                observer_or_fake_quant_ctr=act_observer_or_fake_quant_ctr.with_args(
+                                                eps=2**-12
+                                            ),)
+
+                                            for key in n.meta["quantization_annotation"].input_qspec_map:
+                                                n.meta["quantization_annotation"].input_qspec_map[key] = float_spec
+
+                                            #n.meta["quantization_annotation"].output_qspec = int_spec
+
+                                if n.target in [torch.ops.aten.gelu.default]:
+                                    input_qspec_map = {}
+                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                        input_qspec_map=input_qspec_map,
+                                        output_qspec=get_output_act_qspec(quantization_config),
+                                        _annotated=True,
+                                    )
+
+                            return model
+
+                    if False:
+                        quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
+                            quantization_config
+                        )
+                    else:
+                        quantizer = PT2EQuantizerPromptEncoder().set_global(
+                            quantization_config
+                        )
+
                     model = torch._export.capture_pre_autograd_graph(self.model.sam_prompt_encoder, sample_inputs)
                     model = quantize_pt2e.prepare_pt2e(model, quantizer)
-                    model(concat_points[0], concat_points[1], mask_input_dummy, masks_enable) # calibration
+
+                    import glob
+                    images = glob.glob("./calibration/prompt_encoder/*.npz")
+                    if len(images) == 0:
+                        raise Exception("Calibration data not found. Please run --mode calibration first.")
+
+                    for i in range(len(images)):
+                        npz = np.load(images[i])
+                        data0 = torch.tensor(npz["arr_0"])
+                        data1 = torch.tensor(npz["arr_1"])
+                        data2 = torch.tensor(npz["arr_2"])
+                        data3 = torch.tensor(npz["arr_3"])
+                        model(data0, data1, data2, data3) # calibration
+    
                     model = quantize_pt2e.convert_pt2e(model, fold_quantize=False)
 
                     with_quantizer = ai_edge_torch.convert(
@@ -717,9 +783,9 @@ class SAM2ImagePredictor:
 
                     tfl_fullint_model.export("model/prompt_encoder_"+model_id+".int8.tflite")
 
-        if tflite_int8:
-            tflite_int8_prompt_encoder = False # 精度不足なのでFloatモデルで推論する
-            print("Warning : prompt encoder will use float model for better accuracy.")
+        #if tflite_int8:
+        #    tflite_int8_prompt_encoder = False # 精度不足なのでFloatモデルで推論する
+        #    print("Warning : prompt encoder will use float model for better accuracy.")
 
         if import_from_tflite:
             if self.prompt_encoder_tflite == None:

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -840,13 +840,182 @@ class SAM2ImagePredictor:
 
             if tflite_int8:
                 if tflite_int8 == "mixed":
+                    import ai_edge_torch
+
                     # torch quantization
                     from ai_edge_torch.quantize import pt2e_quantizer
                     from ai_edge_torch.quantize import quant_config
                     from torch.ao.quantization import quantize_pt2e
 
-                    quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
-                        pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=False) # Trueだとエラー
+                    # quantize transpose_conv
+                    from ai_edge_torch.quantize.pt2e_quantizer_utils import QuantizationConfig, register_annotator, get_input_act_qspec, get_weight_qspec, get_bias_qspec, _is_annotated, get_output_act_qspec, _mark_nodes_as_annotated
+                    from typing import Callable, Dict, List, Optional
+                    from torch.ao.quantization.quantizer import QuantizationAnnotation
+                    from torch.fx import Node
+                    from ai_edge_torch.quantize.pt2e_quantizer_utils import propagate_annotation
+                    from ai_edge_torch.quantize.pt2e_quantizer_utils import OperatorPatternType
+                    import torch.nn.functional as F
+                    import copy
+
+                    #@register_annotator("transpose_conv")
+                    def _annotate_transpose_conv(
+                        gm: torch.fx.GraphModule,
+                        quantization_config: Optional[QuantizationConfig],
+                        filter_fn: Optional[Callable[[Node], bool]] = None,
+                    ) -> Optional[List[List[Node]]]:
+                        annotated_partitions = []
+                        for n in gm.graph.nodes:
+                            print(n.target)
+                            if n.op != "call_function" or n.target not in [
+                                torch.ops.aten.conv_transpose2d, torch.ops.aten.conv_transpose2d.input,
+                            ]:
+                                continue
+                            print("# transpose_conv")
+                            conv_node = n
+                            print(conv_node.args)
+
+                            input_qspec_map = {}
+                            input_act = conv_node.args[0]
+                            assert isinstance(input_act, Node)
+                            input_qspec_map[input_act] = get_input_act_qspec(quantization_config)
+                            
+                            weight = conv_node.args[1]
+                            assert isinstance(weight, Node)
+                            input_qspec_map[weight] = get_weight_qspec(quantization_config)
+
+                            bias = conv_node.args[2]
+                            assert isinstance(bias, Node)
+                            input_qspec_map[bias] = get_bias_qspec(quantization_config)
+                             
+                            # adding weight node to the partition as well
+                            partition = [conv_node, conv_node.args[1], conv_node.args[2]]
+
+                            if _is_annotated(partition):
+                                continue
+
+                            if filter_fn and any(not filter_fn(n) for n in partition):
+                                continue
+
+                            #bias = conv_node.args[2] if len(conv_node.args) > 2 else None
+                            #if isinstance(bias, Node):
+                            #    print(" bias enable")
+                            #    input_qspec_map[bias] = get_bias_qspec(quantization_config)
+                            #    partition.append(bias)
+
+                            #shape = conv_node.args[3] if len(conv_node.args) > 3 else None
+                            #if isinstance(shape, Node):
+                            #    print(" shape enable")
+                            #    input_qspec_map[shape] = get_bias_qspec(quantization_config)
+                            #    partition.append(shape)
+
+                            #if _is_annotated(partition):
+                            #    print(" not annotated")
+                            #    continue
+
+                            #if filter_fn and any(not filter_fn(n) for n in partition):
+                            #    print(" not in filter")
+                            #    continue
+
+                            #print(input_qspec_map)
+                            #print(get_output_act_qspec(quantization_config))
+
+
+                            conv_node.meta["quantization_annotation"] = QuantizationAnnotation(
+                                input_qspec_map=input_qspec_map,
+                                output_qspec=get_output_act_qspec(quantization_config),
+                                _annotated=True,
+                            )
+                            _mark_nodes_as_annotated(partition)
+                            annotated_partitions.append(partition)
+                        return annotated_partitions
+
+                    quantization_config = pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=False)
+
+                    class PT2EQuantizer2(pt2e_quantizer.PT2EQuantizer):
+                        # static quantization ops (both PTQ and QAT)
+                        STATIC_OPS = [
+                            "linear",
+                            "addmm",
+                            "conv_relu",
+                            "conv",
+                            "adaptive_avg_pool2d",
+                            "gru_io_only",
+                            "max_pool2d",
+                            "add_relu",
+                            "add",
+                            "mul_relu",
+                            "mul",
+                            "cat",
+                            "fixed_qparams",
+                            #"transpose_conv", # added
+                        ]
+
+                        def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                            super().annotate(model)
+                            
+                            #model = self._annotate_for_static_quantization_config(model)
+
+                            for n in model.graph.nodes:
+                                print(n.target, n.meta)
+                                
+                                if n.target in [torch.ops.aten.conv_transpose2d.input]:
+                                    #print(n.target, n.meta)
+
+                                    # StableHLOの内部でweightがtransposeされるためにqdqの変換がうまくいかず、完全にint8にはできない
+                                    # ただ、layernormの出力のquantizeでパーティションを分割して、dq -> transposeconv -> qとするために、
+                                    # 入力側にはint8の制約をかける
+
+                                    input_qspec_map = {}
+
+                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+                                    #input_qspec_map[n.args[1]] = get_weight_qspec(quantization_config)
+                                    #input_qspec_map[n.args[2]] = get_bias_qspec(quantization_config)
+
+                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                        input_qspec_map=input_qspec_map,
+                                        output_qspec=get_output_act_qspec(quantization_config),
+                                        _annotated=True,
+                                    )
+
+                                    print(n.target, n.meta)
+
+                                if False:#n.target in [torch.ops.aten.linear.default]:
+                                    #print(n.target, n.meta)
+
+                                    input_qspec_map = {}
+
+                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+                                    input_qspec_map[n.args[1]] = get_input_act_qspec(quantization_config)
+
+                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                        input_qspec_map=input_qspec_map,
+                                        output_qspec=get_output_act_qspec(quantization_config),
+                                        _annotated=True,
+                                    )
+
+                                    print(n.target, n.meta)
+
+                                if False:#n.target in [torch.ops.aten.gelu.default]:
+                                    #print(n.target, n.meta)
+
+                                    input_qspec_map = {}
+
+                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+
+                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                        input_qspec_map=input_qspec_map,
+                                        output_qspec=get_output_act_qspec(quantization_config),
+                                        _annotated=True,
+                                    )
+
+                                    print(n.target, n.meta)
+
+                            #propagate_annotation(model)
+
+                            return model
+
+                    quantizer = PT2EQuantizer2().set_global(
+                        quantization_config
                     )
                     model = torch._export.capture_pre_autograd_graph(self.model.sam_mask_decoder, sample_inputs)
                     model = quantize_pt2e.prepare_pt2e(model, quantizer)

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -959,7 +959,6 @@ class SAM2ImagePredictor:
                             super().annotate(model)
 
                             for n in model.graph.nodes:
-                                if n.target in [torch.ops.aten.conv_transpose2d.input]:
                                 if n.target in [torch.ops.aten.conv_transpose2d.input, torch.ops.aten.linear.default]:
                                     input_qspec_map = {}
 

--- a/sam2/sam2_video_predictor.py
+++ b/sam2/sam2_video_predictor.py
@@ -592,6 +592,7 @@ class SAM2VideoPredictor(SAM2Base):
                 import_from_onnx=import_from_onnx,
                 export_to_tflite=export_to_tflite,
                 import_from_tflite=import_from_tflite,
+                tflite_int8=tflite_int8,
                 model_id=model_id
             )
             consolidated_out["maskmem_features"] = maskmem_features
@@ -1115,7 +1116,7 @@ class SAM2VideoPredictor(SAM2Base):
         high_res_masks,
         object_score_logits,
         is_mask_from_pts,
-        export_to_onnx, import_from_onnx, export_to_tflite, import_from_tflite, model_id
+        export_to_onnx, import_from_onnx, export_to_tflite, import_from_tflite, tflite_int8, model_id
     ):
         """
         Run the memory encoder on `high_res_masks`. This is usually after applying
@@ -1136,6 +1137,7 @@ class SAM2VideoPredictor(SAM2Base):
             import_from_onnx=import_from_onnx,
             export_to_tflite=export_to_tflite,
             import_from_tflite=import_from_tflite,
+            tflite_int8=tflite_int8,
             model_id=model_id
         )
 

--- a/sam2/sam2_video_predictor.py
+++ b/sam2/sam2_video_predictor.py
@@ -979,7 +979,7 @@ class SAM2VideoPredictor(SAM2Base):
                 if tflite_int8:
                     int8_id = ""
                     if tflite_int8:
-                        int8_id = ".int8"
+                        int8_id = "." + tflite_int8
 
                 if self.image_encoder_tflite == None:
                     if import_from_tflite == "ailia_tflite":


### PR DESCRIPTION
SAM2.1のFULLY_INTEGER_QUANTIZATIONのモデルの構築を行う。

Windowsだとedge-ai-torchの依存ライブラリが入らないので、WSLが必要。

```
 python3 export_image_predictor.py --image_size 512 --framework tflite --accuracy int8
```

現段階では、下記の変換エラーが発生する。

```
   output = self._dispatch_impl(func, types, args, kwargs)
  File "/home/kyakuno/.local/lib/python3.10/site-packages/torch/_subclasses/fake_tensor.py", line 1757, in _dispatch_impl
    r = func(*args, **kwargs)
  File "/home/kyakuno/.local/lib/python3.10/site-packages/torch/_ops.py", line 667, in __call__
    return self_._op(*args, **kwargs)
  File "/home/kyakuno/.local/lib/python3.10/site-packages/torch/ao/quantization/fx/_decomposed.py", line 81, in quantize_per_tensor_meta
    assert input.dtype == torch.float32, f"Expecting input to have dtype torch.float32, but got dtype: {input.dtype}"
torch._dynamo.exc.TorchRuntimeError: Failed running call_function quantized_decomposed.quantize_per_tensor.default(*(FakeTensor(..., size=(), dtype=torch.int64), 0.007843137718737125, -128, -128, 127, torch.int8), **{}):
Expecting input to have dtype torch.float32, but got dtype: torch.int64

from user code:
   File "<eval_with_key>.12", line 1083, in forward
    quantize_per_tensor_default_261 = torch.ops.quantized_decomposed.quantize_per_tensor.default(_tensor_constant_9, 0.007843137718737125, -128, -128, 127, torch.int8);  _tensor_constant_9 = None

Set TORCH_LOGS="+dynamo" and TORCHDYNAMO_VERBOSE=1 for more information
```