### PR TITLE
MINCUT for memory encoder, Int8 TransposeConv for mask decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,8 @@ tflite (mixed)
 
 ```
 export PJRT_DEVICE=CPU
-export AIEDGETORCH_LAYOUT_OPTIMIZE_PARTITIONER=MINCUT
 python3 export_image_predictor.py --framework tflite --accuracy mixed --image_size 512
-export AIEDGETORCH_LAYOUT_OPTIMIZE_PARTITIONER=GREEDY
 python3 export_video_predictor.py --framework tflite --accuracy mixed --image_size 512
-```
-
-export AIEDGETORCH_LAYOUT_OPTIMIZE_PARTITIONER=GREEDY requires for below error of memory encoder.
-
-```
-AttributeError: 'OptimizeLayoutTransposesPass' object has no attribute 'get_paired_q_dq_ops'
 ```
 
 ## Inference only

--- a/sam2/build_sam.py
+++ b/sam2/build_sam.py
@@ -164,6 +164,10 @@ def _load_checkpoint(model, ckpt_path):
     if ckpt_path is not None:
         sd = torch.load(ckpt_path, map_location="cpu", weights_only=True)["model"]
         missing_keys, unexpected_keys = model.load_state_dict(sd)
+        for name, module in model.named_modules():
+            from sam2.modeling.sam2_utils import LayerNorm2dWithNN
+            if isinstance(module, LayerNorm2dWithNN):
+                module.load_weights_from_old_model()
         if missing_keys:
             logging.error(missing_keys)
             raise RuntimeError()

--- a/sam2/modeling/memory_encoder.py
+++ b/sam2/modeling/memory_encoder.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from sam2.modeling.sam2_utils import DropPath, get_clones, LayerNorm2d
+from sam2.modeling.sam2_utils import DropPath, get_clones, LayerNorm2d, LayerNorm2dNHWC
 
 
 class MaskDownSampler(nn.Module):
@@ -48,7 +48,7 @@ class MaskDownSampler(nn.Module):
                     padding=padding,
                 )
             )
-            self.encoder.append(LayerNorm2d(mask_out_chans))
+            self.encoder.append(LayerNorm2dNHWC(mask_out_chans))
             self.encoder.append(activation())
             mask_in_chans = mask_out_chans
 
@@ -88,7 +88,7 @@ class CXBlock(nn.Module):
             padding=padding,
             groups=dim if use_dwconv else 1,
         )  # depthwise conv
-        self.norm = LayerNorm2d(dim, eps=1e-6)
+        self.norm = LayerNorm2dNHWC(dim, eps=1e-6)
         self.pwconv1 = nn.Linear(
             dim, 4 * dim
         )  # pointwise/1x1 convs, implemented with linear layers

--- a/sam2/modeling/memory_encoder.py
+++ b/sam2/modeling/memory_encoder.py
@@ -154,6 +154,15 @@ class MemoryEncoder(nn.Module):
         self.out_proj = nn.Identity()
         if out_dim != in_dim:
             self.out_proj = nn.Conv2d(in_dim, out_dim, kernel_size=1)
+        self.pos_cache_enable = False
+        self.pos_cache = None
+
+    def prepare_position_encoding(self, pix_feat: torch.Tensor):
+        x = self.pix_feat_proj(pix_feat)
+        x = self.fuser(x)
+        x = self.out_proj(x)
+        self.pos_cache_enable = True
+        self.pos_cache = self.position_encoding(x).to(x.dtype)
 
     def forward(
         self,
@@ -177,7 +186,8 @@ class MemoryEncoder(nn.Module):
         x = self.fuser(x)
         x = self.out_proj(x)
 
-        pos = self.position_encoding(x).to(x.dtype)
+        assert(self.pos_cache_enable)
+        pos = self.pos_cache
 
         return x, pos
         

--- a/sam2/modeling/memory_encoder.py
+++ b/sam2/modeling/memory_encoder.py
@@ -11,7 +11,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from sam2.modeling.sam2_utils import DropPath, get_clones, LayerNorm2d, LayerNorm2dNHWC
+from sam2.modeling.sam2_utils import DropPath, get_clones, LayerNorm2d, LayerNorm2dWithNN
 
 
 class MaskDownSampler(nn.Module):
@@ -48,7 +48,7 @@ class MaskDownSampler(nn.Module):
                     padding=padding,
                 )
             )
-            self.encoder.append(LayerNorm2dNHWC(mask_out_chans))
+            self.encoder.append(LayerNorm2dWithNN(mask_out_chans))
             self.encoder.append(activation())
             mask_in_chans = mask_out_chans
 
@@ -88,7 +88,7 @@ class CXBlock(nn.Module):
             padding=padding,
             groups=dim if use_dwconv else 1,
         )  # depthwise conv
-        self.norm = LayerNorm2dNHWC(dim, eps=1e-6)
+        self.norm = LayerNorm2dWithNN(dim, eps=1e-6)
         self.pwconv1 = nn.Linear(
             dim, 4 * dim
         )  # pointwise/1x1 convs, implemented with linear layers

--- a/sam2/modeling/sam/mask_decoder.py
+++ b/sam2/modeling/sam/mask_decoder.py
@@ -9,7 +9,7 @@ from typing import List, Optional, Tuple, Type
 import torch
 from torch import nn
 
-from sam2.modeling.sam2_utils import LayerNorm2d, MLP
+from sam2.modeling.sam2_utils import LayerNorm2d, LayerNorm2dWithNN, MLP
 
 
 class MaskDecoder(nn.Module):
@@ -66,7 +66,7 @@ class MaskDecoder(nn.Module):
             nn.ConvTranspose2d(
                 transformer_dim, transformer_dim // 4, kernel_size=2, stride=2
             ),
-            LayerNorm2d(transformer_dim // 4),
+            LayerNorm2dWithNN(transformer_dim // 4),
             activation(),
             nn.ConvTranspose2d(
                 transformer_dim // 4, transformer_dim // 8, kernel_size=2, stride=2

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -1302,9 +1302,46 @@ class SAM2Base(torch.nn.Module):
                     from ai_edge_torch.quantize import quant_config
                     from torch.ao.quantization import quantize_pt2e
 
-                    quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
-                        pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
-                    )
+                    # torch quantization
+                    from ai_edge_torch.quantize import pt2e_quantizer
+                    from ai_edge_torch.quantize import quant_config
+                    from torch.ao.quantization import quantize_pt2e
+
+                    # quantize transpose_conv
+                    from ai_edge_torch.quantize.pt2e_quantizer_utils import get_input_act_qspec, get_weight_qspec, get_bias_qspec, get_output_act_qspec
+                    from torch.ao.quantization.quantizer import QuantizationAnnotation
+
+                    quantization_config = pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
+
+                    class PT2EQuantizer2(pt2e_quantizer.PT2EQuantizer):
+                        def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                            super().annotate(model)
+
+                            target_node = None
+                            for n in model.graph.nodes:
+                                if str(n.target) == "output":
+                                    target_node = n.args[0][0]
+
+                            for n in model.graph.nodes:
+                                if n == target_node:
+                                    input_qspec_map = {}
+                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                        input_qspec_map=input_qspec_map,
+                                        output_qspec=get_output_act_qspec(quantization_config),
+                                        _annotated=True,
+                                    )
+
+                            return model
+
+                    if False:
+                        quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
+                            quantization_config
+                        )
+                    else:
+                        quantizer = PT2EQuantizer2().set_global(
+                            quantization_config
+                        )
                     model = torch._export.capture_pre_autograd_graph(self.memory_attention, sample_inputs)
                     model = quantize_pt2e.prepare_pt2e(model, quantizer)
 

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -1584,42 +1584,44 @@ class SAM2Base(torch.nn.Module):
                     from ai_edge_torch.quantize import quant_config
                     from torch.ao.quantization import quantize_pt2e
 
-                    if True:
+                    quantization_config = pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
+
+                    if False:
                         quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
                             pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
                         )
                     else:
+                        import ai_edge_torch
+
+                        # torch quantization
+                        from ai_edge_torch.quantize import pt2e_quantizer
+                        from ai_edge_torch.quantize import quant_config
+                        from torch.ao.quantization import quantize_pt2e
+
+                        # quantize transpose_conv
+                        from ai_edge_torch.quantize.pt2e_quantizer_utils import get_input_act_qspec, get_output_act_qspec
+                        from torch.ao.quantization.quantizer import QuantizationAnnotation
+
                         class PT2EQuantizer2(pt2e_quantizer.PT2EQuantizer):
                             def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
                                 super().annotate(model)
+
                                 for n in model.graph.nodes:
-                                    print(n.target, n.meta)
-                                    if n.target in [torch.ops.aten.add.Tensor, torch.ops.aten.mean.dim]:
-                                        if "quantization_annotation" in n.meta and ("s = s + self.eps" in n.meta["stack_trace"] or "u = x.mean(3, keepdim=True)" in n.meta["stack_trace"]):
-                                            print(n.target)
-                                            print("Before")
-                                            print(n.meta["quantization_annotation"])
+                                    if n.target in [torch.ops.aten.gelu.default]:
+                                        input_qspec_map = {}
 
-                                            from torch.ao.quantization.quantizer import QuantizationSpec
-                                            from torch.ao.quantization.observer import PlaceholderObserver
-                                            act_observer_or_fake_quant_ctr = PlaceholderObserver
+                                        input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
 
-                                            float_spec = QuantizationSpec(dtype=torch.float32,
-                                                observer_or_fake_quant_ctr=act_observer_or_fake_quant_ctr.with_args(
-                                                eps=2**-12
-                                            ),)
+                                        n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                            input_qspec_map=input_qspec_map,
+                                            output_qspec=get_output_act_qspec(quantization_config),
+                                            _annotated=True,
+                                        )
 
-                                            for key in n.meta["quantization_annotation"].input_qspec_map:
-                                                n.meta["quantization_annotation"].input_qspec_map[key] = float_spec
-
-                                            n.meta["quantization_annotation"].output_qspec = float_spec
-
-                                            print("After")
-                                            print(n.meta["quantization_annotation"])
                                 return model
 
                         quantizer = PT2EQuantizer2().set_global(
-                            pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
+                            quantization_config
                         )
 
                     model = torch._export.capture_pre_autograd_graph(self.memory_encoder, sample_inputs)

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -1565,6 +1565,8 @@ class SAM2Base(torch.nn.Module):
         #if tflite_int8_memory_encoder == "mixed":
         #    tflite_int8_memory_encoder = "int8" # 暫定
 
+        self.memory_encoder.prepare_position_encoding(pix_feat)
+
         if export_to_tflite and not self.memory_encoder_tflite_exported:
             self.memory_encoder_tflite_exported = True
 

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -1584,7 +1584,7 @@ class SAM2Base(torch.nn.Module):
                     from ai_edge_torch.quantize import quant_config
                     from torch.ao.quantization import quantize_pt2e
 
-                    if False:
+                    if True:
                         quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
                             pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
                         )

--- a/sam2/modeling/sam2_utils.py
+++ b/sam2/modeling/sam2_utils.py
@@ -159,7 +159,7 @@ class LayerNorm2dNHWC(nn.Module):
         self.bias = nn.Parameter(torch.zeros(num_channels))
         self.eps = eps
 
-    # for MINCUT
+    # for AIEDGETORCH_LAYOUT_OPTIMIZE_PARTITIONER=MINCUT
     def forward(self, x: torch.Tensor) -> torch.Tensor:
        # Turn into `NHWC` if required or any other specific format
        x = x.permute(0, 2, 3, 1)  # Optional based on requirements

--- a/sam2/modeling/sam2_utils.py
+++ b/sam2/modeling/sam2_utils.py
@@ -145,13 +145,27 @@ class LayerNorm2d(nn.Module):
         self.bias = nn.Parameter(torch.zeros(num_channels))
         self.eps = eps
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        u = x.mean(1, keepdim=True)
-        s = (x - u).pow(2).mean(1, keepdim=True)
-        x = (x - u) / torch.sqrt(s + self.eps)
-        x = self.weight[:, None, None] * x + self.bias[:, None, None]
-        return x
+    # default implementation
+    #def forward(self, x: torch.Tensor) -> torch.Tensor:
+    #    u = x.mean(1, keepdim=True)
+    #    s = (x - u).pow(2).mean(1, keepdim=True)
+    #    x = (x - u) / torch.sqrt(s + self.eps)
+    #    x = self.weight[:, None, None] * x + self.bias[:, None, None]
+    #    return x
 
+    # for MINCUT
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+       # Turn into `NHWC` if required or any other specific format
+       x = x.permute(0, 2, 3, 1)  # Optional based on requirements
+       # Operations here depend on whether Channel is leading or at the end
+       u = x.mean(3, keepdim=True)
+       s = (x - u).pow(2).mean(3, keepdim=True)
+       s = s + self.eps
+       x = (x - u) / torch.sqrt(s)
+       x = self.weight * x + self.bias
+       # Revert back `NCHW`
+       x = x.permute(0, 3, 1, 2)  # If you converted earlier
+       return x
 
 def sample_box_points(
     masks: torch.Tensor,

--- a/sam2/modeling/sam2_utils.py
+++ b/sam2/modeling/sam2_utils.py
@@ -145,13 +145,19 @@ class LayerNorm2d(nn.Module):
         self.bias = nn.Parameter(torch.zeros(num_channels))
         self.eps = eps
 
-    # default implementation
-    #def forward(self, x: torch.Tensor) -> torch.Tensor:
-    #    u = x.mean(1, keepdim=True)
-    #    s = (x - u).pow(2).mean(1, keepdim=True)
-    #    x = (x - u) / torch.sqrt(s + self.eps)
-    #    x = self.weight[:, None, None] * x + self.bias[:, None, None]
-    #    return x
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        u = x.mean(1, keepdim=True)
+        s = (x - u).pow(2).mean(1, keepdim=True)
+        x = (x - u) / torch.sqrt(s + self.eps)
+        x = self.weight[:, None, None] * x + self.bias[:, None, None]
+        return x
+
+class LayerNorm2dNHWC(nn.Module):
+    def __init__(self, num_channels: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(num_channels))
+        self.bias = nn.Parameter(torch.zeros(num_channels))
+        self.eps = eps
 
     # for MINCUT
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/sam2/modeling/sam2_utils.py
+++ b/sam2/modeling/sam2_utils.py
@@ -172,10 +172,9 @@ class LayerNorm2dWithNN(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         assert(self.load_weight)
-        orig_shape = x.shape
-        x = x.view(orig_shape[0], orig_shape[1], -1).transpose(1, 2)  # (N, C, H*W) -> (N, H*W, C)
+        x = x.permute(0, 2, 3, 1)
         x = self.layer_norm(x)
-        x = x.transpose(1, 2).view(orig_shape)  # (N, H*W, C) -> (N, C, H, W)
+        x = x.permute(0, 3, 1, 2)
         return x
 
 def sample_box_points(

--- a/sam2/modeling/sam2_utils.py
+++ b/sam2/modeling/sam2_utils.py
@@ -152,26 +152,31 @@ class LayerNorm2d(nn.Module):
         x = self.weight[:, None, None] * x + self.bias[:, None, None]
         return x
 
-class LayerNorm2dNHWC(nn.Module):
+# Use official nn.layernorm
+# Need to convert original weight to nn.layernorm weight
+class LayerNorm2dWithNN(nn.Module):
     def __init__(self, num_channels: int, eps: float = 1e-6) -> None:
         super().__init__()
+        self.num_channels = num_channels
+        # Set initial weights and biases similar to the original implementation
         self.weight = nn.Parameter(torch.ones(num_channels))
         self.bias = nn.Parameter(torch.zeros(num_channels))
         self.eps = eps
+        self.load_weight = False
 
-    # for AIEDGETORCH_LAYOUT_OPTIMIZE_PARTITIONER=MINCUT
+    def load_weights_from_old_model(self):
+        self.layer_norm = nn.LayerNorm(normalized_shape=self.num_channels, eps=self.eps, elementwise_affine=True)
+        self.layer_norm.weight.data =  self.weight
+        self.layer_norm.bias.data = self.bias
+        self.load_weight = True
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-       # Turn into `NHWC` if required or any other specific format
-       x = x.permute(0, 2, 3, 1)  # Optional based on requirements
-       # Operations here depend on whether Channel is leading or at the end
-       u = x.mean(3, keepdim=True)
-       s = (x - u).pow(2).mean(3, keepdim=True)
-       s = s + self.eps
-       x = (x - u) / torch.sqrt(s)
-       x = self.weight * x + self.bias
-       # Revert back `NCHW`
-       x = x.permute(0, 3, 1, 2)  # If you converted earlier
-       return x
+        assert(self.load_weight)
+        orig_shape = x.shape
+        x = x.view(orig_shape[0], orig_shape[1], -1).transpose(1, 2)  # (N, C, H*W) -> (N, H*W, C)
+        x = self.layer_norm(x)
+        x = x.transpose(1, 2).view(orig_shape)  # (N, H*W, C) -> (N, C, H, W)
+        return x
 
 def sample_box_points(
     masks: torch.Tensor,

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -873,6 +873,15 @@ class SAM2ImagePredictor:
                                         _annotated=True,
                                     )
 
+                                if n.target in [torch.ops.aten.gelu.default]:
+                                    input_qspec_map = {}
+                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                        input_qspec_map=input_qspec_map,
+                                        output_qspec=get_output_act_qspec(quantization_config),
+                                        _annotated=True,
+                                    )
+
                             return model
 
                     if False:

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -848,126 +848,22 @@ class SAM2ImagePredictor:
                     from torch.ao.quantization import quantize_pt2e
 
                     # quantize transpose_conv
-                    from ai_edge_torch.quantize.pt2e_quantizer_utils import QuantizationConfig, register_annotator, get_input_act_qspec, get_weight_qspec, get_bias_qspec, _is_annotated, get_output_act_qspec, _mark_nodes_as_annotated
-                    from typing import Callable, Dict, List, Optional
+                    from ai_edge_torch.quantize.pt2e_quantizer_utils import get_input_act_qspec, get_weight_qspec, get_bias_qspec, get_output_act_qspec
                     from torch.ao.quantization.quantizer import QuantizationAnnotation
-                    from torch.fx import Node
-                    from ai_edge_torch.quantize.pt2e_quantizer_utils import propagate_annotation
-                    from ai_edge_torch.quantize.pt2e_quantizer_utils import OperatorPatternType
-                    import torch.nn.functional as F
-                    import copy
-
-                    #@register_annotator("transpose_conv")
-                    def _annotate_transpose_conv(
-                        gm: torch.fx.GraphModule,
-                        quantization_config: Optional[QuantizationConfig],
-                        filter_fn: Optional[Callable[[Node], bool]] = None,
-                    ) -> Optional[List[List[Node]]]:
-                        annotated_partitions = []
-                        for n in gm.graph.nodes:
-                            print(n.target)
-                            if n.op != "call_function" or n.target not in [
-                                torch.ops.aten.conv_transpose2d, torch.ops.aten.conv_transpose2d.input,
-                            ]:
-                                continue
-                            print("# transpose_conv")
-                            conv_node = n
-                            print(conv_node.args)
-
-                            input_qspec_map = {}
-                            input_act = conv_node.args[0]
-                            assert isinstance(input_act, Node)
-                            input_qspec_map[input_act] = get_input_act_qspec(quantization_config)
-                            
-                            weight = conv_node.args[1]
-                            assert isinstance(weight, Node)
-                            input_qspec_map[weight] = get_weight_qspec(quantization_config)
-
-                            bias = conv_node.args[2]
-                            assert isinstance(bias, Node)
-                            input_qspec_map[bias] = get_bias_qspec(quantization_config)
-                             
-                            # adding weight node to the partition as well
-                            partition = [conv_node, conv_node.args[1], conv_node.args[2]]
-
-                            if _is_annotated(partition):
-                                continue
-
-                            if filter_fn and any(not filter_fn(n) for n in partition):
-                                continue
-
-                            #bias = conv_node.args[2] if len(conv_node.args) > 2 else None
-                            #if isinstance(bias, Node):
-                            #    print(" bias enable")
-                            #    input_qspec_map[bias] = get_bias_qspec(quantization_config)
-                            #    partition.append(bias)
-
-                            #shape = conv_node.args[3] if len(conv_node.args) > 3 else None
-                            #if isinstance(shape, Node):
-                            #    print(" shape enable")
-                            #    input_qspec_map[shape] = get_bias_qspec(quantization_config)
-                            #    partition.append(shape)
-
-                            #if _is_annotated(partition):
-                            #    print(" not annotated")
-                            #    continue
-
-                            #if filter_fn and any(not filter_fn(n) for n in partition):
-                            #    print(" not in filter")
-                            #    continue
-
-                            #print(input_qspec_map)
-                            #print(get_output_act_qspec(quantization_config))
-
-
-                            conv_node.meta["quantization_annotation"] = QuantizationAnnotation(
-                                input_qspec_map=input_qspec_map,
-                                output_qspec=get_output_act_qspec(quantization_config),
-                                _annotated=True,
-                            )
-                            _mark_nodes_as_annotated(partition)
-                            annotated_partitions.append(partition)
-                        return annotated_partitions
 
                     quantization_config = pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=False)
 
                     class PT2EQuantizer2(pt2e_quantizer.PT2EQuantizer):
-                        # static quantization ops (both PTQ and QAT)
-                        STATIC_OPS = [
-                            "linear",
-                            "addmm",
-                            "conv_relu",
-                            "conv",
-                            "adaptive_avg_pool2d",
-                            "gru_io_only",
-                            "max_pool2d",
-                            "add_relu",
-                            "add",
-                            "mul_relu",
-                            "mul",
-                            "cat",
-                            "fixed_qparams",
-                            #"transpose_conv", # added
-                        ]
-
                         def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
                             super().annotate(model)
-                            
-                            #model = self._annotate_for_static_quantization_config(model)
 
                             for n in model.graph.nodes:
-                                print(n.target, n.meta)
-                                
                                 if n.target in [torch.ops.aten.conv_transpose2d.input]:
-                                    #print(n.target, n.meta)
-
-                                    # StableHLOの内部でweightがtransposeされるためにqdqの変換がうまくいかず、完全にint8にはできない
-                                    # ただ、layernormの出力のquantizeでパーティションを分割して、dq -> transposeconv -> qとするために、
-                                    # 入力側にはint8の制約をかける
-
                                     input_qspec_map = {}
 
                                     input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+
+                                    # weightにも制約をかけるとうまくint8に変換できなくなるため、inputにだけ制約をかける
                                     #input_qspec_map[n.args[1]] = get_weight_qspec(quantization_config)
                                     #input_qspec_map[n.args[2]] = get_bias_qspec(quantization_config)
 
@@ -977,46 +873,16 @@ class SAM2ImagePredictor:
                                         _annotated=True,
                                     )
 
-                                    print(n.target, n.meta)
-
-                                if False:#n.target in [torch.ops.aten.linear.default]:
-                                    #print(n.target, n.meta)
-
-                                    input_qspec_map = {}
-
-                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
-                                    input_qspec_map[n.args[1]] = get_input_act_qspec(quantization_config)
-
-                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
-                                        input_qspec_map=input_qspec_map,
-                                        output_qspec=get_output_act_qspec(quantization_config),
-                                        _annotated=True,
-                                    )
-
-                                    print(n.target, n.meta)
-
-                                if False:#n.target in [torch.ops.aten.gelu.default]:
-                                    #print(n.target, n.meta)
-
-                                    input_qspec_map = {}
-
-                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
-
-                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
-                                        input_qspec_map=input_qspec_map,
-                                        output_qspec=get_output_act_qspec(quantization_config),
-                                        _annotated=True,
-                                    )
-
-                                    print(n.target, n.meta)
-
-                            #propagate_annotation(model)
-
                             return model
 
-                    quantizer = PT2EQuantizer2().set_global(
-                        quantization_config
-                    )
+                    if False:
+                        quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
+                            quantization_config
+                        )
+                    else:
+                        quantizer = PT2EQuantizer2().set_global(
+                            quantization_config
+                        )
                     model = torch._export.capture_pre_autograd_graph(self.model.sam_mask_decoder, sample_inputs)
                     model = quantize_pt2e.prepare_pt2e(model, quantizer)
 

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -840,13 +840,182 @@ class SAM2ImagePredictor:
 
             if tflite_int8:
                 if tflite_int8 == "mixed":
+                    import ai_edge_torch
+
                     # torch quantization
                     from ai_edge_torch.quantize import pt2e_quantizer
                     from ai_edge_torch.quantize import quant_config
                     from torch.ao.quantization import quantize_pt2e
 
-                    quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
-                        pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=False) # Trueだとエラー
+                    # quantize transpose_conv
+                    from ai_edge_torch.quantize.pt2e_quantizer_utils import QuantizationConfig, register_annotator, get_input_act_qspec, get_weight_qspec, get_bias_qspec, _is_annotated, get_output_act_qspec, _mark_nodes_as_annotated
+                    from typing import Callable, Dict, List, Optional
+                    from torch.ao.quantization.quantizer import QuantizationAnnotation
+                    from torch.fx import Node
+                    from ai_edge_torch.quantize.pt2e_quantizer_utils import propagate_annotation
+                    from ai_edge_torch.quantize.pt2e_quantizer_utils import OperatorPatternType
+                    import torch.nn.functional as F
+                    import copy
+
+                    #@register_annotator("transpose_conv")
+                    def _annotate_transpose_conv(
+                        gm: torch.fx.GraphModule,
+                        quantization_config: Optional[QuantizationConfig],
+                        filter_fn: Optional[Callable[[Node], bool]] = None,
+                    ) -> Optional[List[List[Node]]]:
+                        annotated_partitions = []
+                        for n in gm.graph.nodes:
+                            print(n.target)
+                            if n.op != "call_function" or n.target not in [
+                                torch.ops.aten.conv_transpose2d, torch.ops.aten.conv_transpose2d.input,
+                            ]:
+                                continue
+                            print("# transpose_conv")
+                            conv_node = n
+                            print(conv_node.args)
+
+                            input_qspec_map = {}
+                            input_act = conv_node.args[0]
+                            assert isinstance(input_act, Node)
+                            input_qspec_map[input_act] = get_input_act_qspec(quantization_config)
+                            
+                            weight = conv_node.args[1]
+                            assert isinstance(weight, Node)
+                            input_qspec_map[weight] = get_weight_qspec(quantization_config)
+
+                            bias = conv_node.args[2]
+                            assert isinstance(bias, Node)
+                            input_qspec_map[bias] = get_bias_qspec(quantization_config)
+                             
+                            # adding weight node to the partition as well
+                            partition = [conv_node, conv_node.args[1], conv_node.args[2]]
+
+                            if _is_annotated(partition):
+                                continue
+
+                            if filter_fn and any(not filter_fn(n) for n in partition):
+                                continue
+
+                            #bias = conv_node.args[2] if len(conv_node.args) > 2 else None
+                            #if isinstance(bias, Node):
+                            #    print(" bias enable")
+                            #    input_qspec_map[bias] = get_bias_qspec(quantization_config)
+                            #    partition.append(bias)
+
+                            #shape = conv_node.args[3] if len(conv_node.args) > 3 else None
+                            #if isinstance(shape, Node):
+                            #    print(" shape enable")
+                            #    input_qspec_map[shape] = get_bias_qspec(quantization_config)
+                            #    partition.append(shape)
+
+                            #if _is_annotated(partition):
+                            #    print(" not annotated")
+                            #    continue
+
+                            #if filter_fn and any(not filter_fn(n) for n in partition):
+                            #    print(" not in filter")
+                            #    continue
+
+                            #print(input_qspec_map)
+                            #print(get_output_act_qspec(quantization_config))
+
+
+                            conv_node.meta["quantization_annotation"] = QuantizationAnnotation(
+                                input_qspec_map=input_qspec_map,
+                                output_qspec=get_output_act_qspec(quantization_config),
+                                _annotated=True,
+                            )
+                            _mark_nodes_as_annotated(partition)
+                            annotated_partitions.append(partition)
+                        return annotated_partitions
+
+                    quantization_config = pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=False)
+
+                    class PT2EQuantizer2(pt2e_quantizer.PT2EQuantizer):
+                        # static quantization ops (both PTQ and QAT)
+                        STATIC_OPS = [
+                            "linear",
+                            "addmm",
+                            "conv_relu",
+                            "conv",
+                            "adaptive_avg_pool2d",
+                            "gru_io_only",
+                            "max_pool2d",
+                            "add_relu",
+                            "add",
+                            "mul_relu",
+                            "mul",
+                            "cat",
+                            "fixed_qparams",
+                            #"transpose_conv", # added
+                        ]
+
+                        def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                            super().annotate(model)
+                            
+                            #model = self._annotate_for_static_quantization_config(model)
+
+                            for n in model.graph.nodes:
+                                print(n.target, n.meta)
+                                
+                                if n.target in [torch.ops.aten.conv_transpose2d.input]:
+                                    #print(n.target, n.meta)
+
+                                    # StableHLOの内部でweightがtransposeされるためにqdqの変換がうまくいかず、完全にint8にはできない
+                                    # ただ、layernormの出力のquantizeでパーティションを分割して、dq -> transposeconv -> qとするために、
+                                    # 入力側にはint8の制約をかける
+
+                                    input_qspec_map = {}
+
+                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+                                    #input_qspec_map[n.args[1]] = get_weight_qspec(quantization_config)
+                                    #input_qspec_map[n.args[2]] = get_bias_qspec(quantization_config)
+
+                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                        input_qspec_map=input_qspec_map,
+                                        output_qspec=get_output_act_qspec(quantization_config),
+                                        _annotated=True,
+                                    )
+
+                                    print(n.target, n.meta)
+
+                                if False:#n.target in [torch.ops.aten.linear.default]:
+                                    #print(n.target, n.meta)
+
+                                    input_qspec_map = {}
+
+                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+                                    input_qspec_map[n.args[1]] = get_input_act_qspec(quantization_config)
+
+                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                        input_qspec_map=input_qspec_map,
+                                        output_qspec=get_output_act_qspec(quantization_config),
+                                        _annotated=True,
+                                    )
+
+                                    print(n.target, n.meta)
+
+                                if False:#n.target in [torch.ops.aten.gelu.default]:
+                                    #print(n.target, n.meta)
+
+                                    input_qspec_map = {}
+
+                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+
+                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                        input_qspec_map=input_qspec_map,
+                                        output_qspec=get_output_act_qspec(quantization_config),
+                                        _annotated=True,
+                                    )
+
+                                    print(n.target, n.meta)
+
+                            #propagate_annotation(model)
+
+                            return model
+
+                    quantizer = PT2EQuantizer2().set_global(
+                        quantization_config
                     )
                     model = torch._export.capture_pre_autograd_graph(self.model.sam_mask_decoder, sample_inputs)
                     model = quantize_pt2e.prepare_pt2e(model, quantizer)


### PR DESCRIPTION
- Memory Encodeにおいて、nn.LayerNormを使用することで、MINCUTに対応
- Mask Decoderにおいて、TransposeConvにAnnotationを適用することで、Int8演算に対応
- Mask Decoderにおいて、geluをInt8に固定
- Memory Attentionにおいて、outputをInt8に固定

Memory Encoderにおいて、MINCUTのパーティショニングでエラーが発生している問題を解消します。

独自のLayerNorm2Dの実装の、Residual Blockの分岐で、NHWCとNCHWが衝突しているのが原因であるため、
公式のnn.layernormに置き換えることで問題を回避します。
独自実装のウエイトをnn.layrernormに登録する必要があるため、checkpointの読み込み時に、load_weights_from_old_modelを呼び出します。

これにより、Addのepsilonが量子化されて0になる問題も回避することが可能です。
MemoryEncoderとMaskDecoderのLayerNormで0加算とsqrtでinfが発生する問題を解消します。

公式のnn.layernormに置き換えずに、NHWC変換後に独自のLayerNormを呼び出す方法でも回避可能です。
その場合、ai-edge-torch 0.2.0だと、ai_edge_torch/convert/fx_passes/optimize_layout_transposes_pass/pass_body.pyのinsert_dq_t_qのself.get_paired_q_dq_ops(input_q.target)をutils.get_paired_q_dq_ops(input_q.target)に修正が必要です。