### PR TITLE
PromptEncoderのInt8量子化

### DIFF
--- a/sam2/build_sam.py
+++ b/sam2/build_sam.py
@@ -165,8 +165,8 @@ def _load_checkpoint(model, ckpt_path):
         sd = torch.load(ckpt_path, map_location="cpu", weights_only=True)["model"]
         missing_keys, unexpected_keys = model.load_state_dict(sd)
         for name, module in model.named_modules():
-            from sam2.modeling.sam2_utils import LayerNorm2dWithNN
-            if isinstance(module, LayerNorm2dWithNN):
+            from sam2.modeling.sam2_utils import LayerNorm2dWithNN, LayerNorm2dWithNN3Dim
+            if isinstance(module, LayerNorm2dWithNN) or isinstance(module, LayerNorm2dWithNN3Dim):
                 module.load_weights_from_old_model()
         if missing_keys:
             logging.error(missing_keys)

--- a/sam2/modeling/position_encoding.py
+++ b/sam2/modeling/position_encoding.py
@@ -162,8 +162,8 @@ class PositionEmbeddingRandom(nn.Module):
         """Positionally encode points that are not normalized to [0,1]."""
         coords = coords_input.clone()
         #coords[:, :, 0] = coords[:, :, 0] / image_size[1] # このままだと順番に書き換えるためにselectv2が生成される
-        #coords[:, :, 1] = coords[:, :, 1] / image_size[0]
-        coords[:, :, :2] /= torch.tensor(image_size[::-1])
+        #coords[:, :, 1] = coords[:, :, 1] / image_size[0] # その結果、量子化係数を適切に決定できず、リスケーリング後に0に落ちる
+        coords[:, :, :2] /= torch.tensor(image_size[::-1], dtype = torch.float32)
         return self._pe_encoding(coords.to(torch.float))  # B x N x C
 
 

--- a/sam2/modeling/position_encoding.py
+++ b/sam2/modeling/position_encoding.py
@@ -137,7 +137,7 @@ class PositionEmbeddingRandom(nn.Module):
     def _pe_encoding(self, coords: torch.Tensor) -> torch.Tensor:
         """Positionally encode points that are normalized to [0,1]."""
         # assuming coords are in [0, 1]^2 square and have d_1 x ... x d_n x 2 shape
-        coords = 2 * coords - 1
+        coords = 2.0 * coords - 1 # 2だとint32 x int32になりtorchの量子化に失敗する
         coords = coords @ self.positional_encoding_gaussian_matrix
         coords = 2 * np.pi * coords
         # outputs d_1 x ... x d_n x C shape

--- a/sam2/modeling/position_encoding.py
+++ b/sam2/modeling/position_encoding.py
@@ -161,8 +161,9 @@ class PositionEmbeddingRandom(nn.Module):
     ) -> torch.Tensor:
         """Positionally encode points that are not normalized to [0,1]."""
         coords = coords_input.clone()
-        coords[:, :, 0] = coords[:, :, 0] / image_size[1]
-        coords[:, :, 1] = coords[:, :, 1] / image_size[0]
+        #coords[:, :, 0] = coords[:, :, 0] / image_size[1] # このままだと順番に書き換えるためにselectv2が生成される
+        #coords[:, :, 1] = coords[:, :, 1] / image_size[0]
+        coords[:, :, :2] /= torch.tensor(image_size[::-1])
         return self._pe_encoding(coords.to(torch.float))  # B x N x C
 
 

--- a/sam2/modeling/sam/prompt_encoder.py
+++ b/sam2/modeling/sam/prompt_encoder.py
@@ -56,14 +56,17 @@ class PromptEncoder(nn.Module):
         )
         self.mask_downscaling = nn.Sequential(
             nn.Conv2d(1, mask_in_chans // 4, kernel_size=2, stride=2),
-            LayerNorm2d(mask_in_chans // 4),
+            LayerNorm2dWithNN3Dim(mask_in_chans // 4),
             activation(),
             nn.Conv2d(mask_in_chans // 4, mask_in_chans, kernel_size=2, stride=2),
-            LayerNorm2d(mask_in_chans),
+            LayerNorm2dWithNN3Dim(mask_in_chans),
             activation(),
             nn.Conv2d(mask_in_chans, embed_dim, kernel_size=1),
         )
         self.no_mask_embed = nn.Embedding(1, embed_dim)
+        self.dense_pe = None
+    
+    def generate_dense_pe(self):
         self.dense_pe = self.pe_layer(self.image_embedding_size).unsqueeze(0) # constantにする
 
     def get_dense_pe(self) -> torch.Tensor:
@@ -75,6 +78,7 @@ class PromptEncoder(nn.Module):
           torch.Tensor: Positional encoding with shape
             1x(embed_dim)x(embedding_h)x(embedding_w)
         """
+        #assert(self.dense_pe != None)
         return self.dense_pe
 
     def _embed_points(

--- a/sam2/modeling/sam/prompt_encoder.py
+++ b/sam2/modeling/sam/prompt_encoder.py
@@ -11,7 +11,7 @@ from torch import nn
 
 from sam2.modeling.position_encoding import PositionEmbeddingRandom
 
-from sam2.modeling.sam2_utils import LayerNorm2d
+from sam2.modeling.sam2_utils import LayerNorm2d, LayerNorm2dWithNN3Dim
 
 
 class PromptEncoder(nn.Module):
@@ -64,6 +64,7 @@ class PromptEncoder(nn.Module):
             nn.Conv2d(mask_in_chans, embed_dim, kernel_size=1),
         )
         self.no_mask_embed = nn.Embedding(1, embed_dim)
+        self.dense_pe = self.pe_layer(self.image_embedding_size).unsqueeze(0) # constantにする
 
     def get_dense_pe(self) -> torch.Tensor:
         """
@@ -74,7 +75,7 @@ class PromptEncoder(nn.Module):
           torch.Tensor: Positional encoding with shape
             1x(embed_dim)x(embedding_h)x(embedding_w)
         """
-        return self.pe_layer(self.image_embedding_size).unsqueeze(0)
+        return self.dense_pe
 
     def _embed_points(
         self,

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -602,6 +602,7 @@ class SAM2Base(torch.nn.Module):
             else:
                 mask_input_dummy = sam_mask_prompt
                 masks_enable = torch.tensor([1], dtype=torch.int)
+            self.sam_prompt_encoder.generate_dense_pe()
             sparse_embeddings, dense_embeddings, dense_pe = self.sam_prompt_encoder.forward(
                 coords=sam_point_coords,
                 labels=sam_point_labels,

--- a/sam2/modeling/sam2_utils.py
+++ b/sam2/modeling/sam2_utils.py
@@ -177,6 +177,29 @@ class LayerNorm2dWithNN(nn.Module):
         x = x.permute(0, 3, 1, 2)
         return x
 
+class LayerNorm2dWithNN3Dim(nn.Module):
+    def __init__(self, num_channels: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.num_channels = num_channels
+        # Set initial weights and biases similar to the original implementation
+        self.weight = nn.Parameter(torch.ones(num_channels))
+        self.bias = nn.Parameter(torch.zeros(num_channels))
+        self.eps = eps
+        self.load_weight = False
+
+    def load_weights_from_old_model(self):
+        self.layer_norm = nn.LayerNorm(normalized_shape=self.num_channels, eps=self.eps, elementwise_affine=True)
+        self.layer_norm.weight.data =  self.weight
+        self.layer_norm.bias.data = self.bias
+        self.load_weight = True
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        assert(self.load_weight)
+        x = x.permute(1, 2, 0)
+        x = self.layer_norm(x)
+        x = x.permute(2, 0, 1)
+        return x
+
 def sample_box_points(
     masks: torch.Tensor,
     noise: float = 0.1,  # SAM default

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -628,6 +628,8 @@ class SAM2ImagePredictor:
         else:
             mask_input_dummy = mask_input
             masks_enable = torch.tensor([1], dtype=torch.int)
+        
+        self.model.sam_prompt_encoder.generate_dense_pe()
 
         if export_to_onnx:
             #print("concat_points", concat_points.shape)
@@ -666,7 +668,6 @@ class SAM2ImagePredictor:
             if tflite_int8_prompt_encoder:
                 if tflite_int8 == "mixed":
                     # torch quantization
-                    # labelがint64で量子化できないため、floatにannotateして扱う
                     from ai_edge_torch.quantize import pt2e_quantizer
                     from ai_edge_torch.quantize import quant_config
                     from torch.ao.quantization import quantize_pt2e
@@ -690,6 +691,7 @@ class SAM2ImagePredictor:
                                 #    print(n.meta["quantization_annotation"])
 
                                 if n.target in [torch.ops.aten.cat.default]:
+                                    # labelがint64で量子化できないため、floatにannotateして扱う
                                     if "quantization_annotation" in n.meta:
                                         #print(str(n.args[0][0]))
                                         if str(n.args[0][0]) == "arg1_1":
@@ -708,6 +710,7 @@ class SAM2ImagePredictor:
                                             #n.meta["quantization_annotation"].output_qspec = int_spec
 
                                 if n.target in [torch.ops.aten.gelu.default]:
+                                    # geluをint8で実行
                                     input_qspec_map = {}
                                     input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
                                     n.meta["quantization_annotation"] = QuantizationAnnotation(

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -709,10 +709,11 @@ class SAM2ImagePredictor:
 
                                             #n.meta["quantization_annotation"].output_qspec = int_spec
 
-                                if n.target in [torch.ops.aten.gelu.default]:
-                                    # geluをint8で実行
+                                if n.target in [torch.ops.aten.gelu.default, torch.ops.aten.sin.default, torch.ops.aten.cos.default, torch.ops.aten.div_.Tensor]:
+                                    # geluとdivをint8で実行
                                     input_qspec_map = {}
-                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+                                    for i in range(len(n.args)):
+                                        input_qspec_map[n.args[i]] = get_input_act_qspec(quantization_config)
                                     n.meta["quantization_annotation"] = QuantizationAnnotation(
                                         input_qspec_map=input_qspec_map,
                                         output_qspec=get_output_act_qspec(quantization_config),

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -664,19 +664,85 @@ class SAM2ImagePredictor:
                 edge_model.export("model/prompt_encoder_"+model_id+".tflite")
 
             if tflite_int8_prompt_encoder:
-                if False:
+                if tflite_int8 == "mixed":
                     # torch quantization
-                    # labelがint64で量子化できない
+                    # labelがint64で量子化できないため、floatにannotateして扱う
                     from ai_edge_torch.quantize import pt2e_quantizer
                     from ai_edge_torch.quantize import quant_config
                     from torch.ao.quantization import quantize_pt2e
 
-                    quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
-                        pt2e_quantizer.get_symmetric_quantization_config()
-                    )
+                    # torch quantization
+                    from ai_edge_torch.quantize import pt2e_quantizer
+                    from ai_edge_torch.quantize import quant_config
+                    from torch.ao.quantization import quantize_pt2e
+                    from ai_edge_torch.quantize.pt2e_quantizer_utils import get_input_act_qspec, get_output_act_qspec
+                    from torch.ao.quantization.quantizer import QuantizationAnnotation
+
+                    quantization_config = pt2e_quantizer.get_symmetric_quantization_config(is_dynamic=False, is_per_channel=True)
+
+                    class PT2EQuantizerPromptEncoder(pt2e_quantizer.PT2EQuantizer):
+                        def annotate(self, model: torch.fx.GraphModule) -> torch.fx.GraphModule:
+                            super().annotate(model)
+
+                            for n in model.graph.nodes:
+                                #print(n.target, n.name)
+                                #if "quantization_annotation" in n.meta:
+                                #    print(n.meta["quantization_annotation"])
+
+                                if n.target in [torch.ops.aten.cat.default]:
+                                    if "quantization_annotation" in n.meta:
+                                        #print(str(n.args[0][0]))
+                                        if str(n.args[0][0]) == "arg1_1":
+                                            from torch.ao.quantization.quantizer import QuantizationSpec
+                                            from torch.ao.quantization.observer import PlaceholderObserver
+                                            act_observer_or_fake_quant_ctr = PlaceholderObserver
+
+                                            float_spec = QuantizationSpec(dtype=torch.float32,
+                                                observer_or_fake_quant_ctr=act_observer_or_fake_quant_ctr.with_args(
+                                                eps=2**-12
+                                            ),)
+
+                                            for key in n.meta["quantization_annotation"].input_qspec_map:
+                                                n.meta["quantization_annotation"].input_qspec_map[key] = float_spec
+
+                                            #n.meta["quantization_annotation"].output_qspec = int_spec
+
+                                if n.target in [torch.ops.aten.gelu.default]:
+                                    input_qspec_map = {}
+                                    input_qspec_map[n.args[0]] = get_input_act_qspec(quantization_config)
+                                    n.meta["quantization_annotation"] = QuantizationAnnotation(
+                                        input_qspec_map=input_qspec_map,
+                                        output_qspec=get_output_act_qspec(quantization_config),
+                                        _annotated=True,
+                                    )
+
+                            return model
+
+                    if False:
+                        quantizer = pt2e_quantizer.PT2EQuantizer().set_global(
+                            quantization_config
+                        )
+                    else:
+                        quantizer = PT2EQuantizerPromptEncoder().set_global(
+                            quantization_config
+                        )
+
                     model = torch._export.capture_pre_autograd_graph(self.model.sam_prompt_encoder, sample_inputs)
                     model = quantize_pt2e.prepare_pt2e(model, quantizer)
-                    model(concat_points[0], concat_points[1], mask_input_dummy, masks_enable) # calibration
+
+                    import glob
+                    images = glob.glob("./calibration/prompt_encoder/*.npz")
+                    if len(images) == 0:
+                        raise Exception("Calibration data not found. Please run --mode calibration first.")
+
+                    for i in range(len(images)):
+                        npz = np.load(images[i])
+                        data0 = torch.tensor(npz["arr_0"])
+                        data1 = torch.tensor(npz["arr_1"])
+                        data2 = torch.tensor(npz["arr_2"])
+                        data3 = torch.tensor(npz["arr_3"])
+                        model(data0, data1, data2, data3) # calibration
+    
                     model = quantize_pt2e.convert_pt2e(model, fold_quantize=False)
 
                     with_quantizer = ai_edge_torch.convert(
@@ -717,9 +783,9 @@ class SAM2ImagePredictor:
 
                     tfl_fullint_model.export("model/prompt_encoder_"+model_id+".int8.tflite")
 
-        if tflite_int8:
-            tflite_int8_prompt_encoder = False # 精度不足なのでFloatモデルで推論する
-            print("Warning : prompt encoder will use float model for better accuracy.")
+        #if tflite_int8:
+        #    tflite_int8_prompt_encoder = False # 精度不足なのでFloatモデルで推論する
+        #    print("Warning : prompt encoder will use float model for better accuracy.")
 
         if import_from_tflite:
             if self.prompt_encoder_tflite == None:


### PR DESCRIPTION
torchのmixedでPromptEncoderをInt8量子化できるようにしました。

- LayerNormを独自実装から公式の実装に変更（3次元なのでクラス追加）
- 2を乗算した場合にint32 x int32の乗算になり量子化できない問題を修正
- 画像サイズで除算する際、widthとheightを独立して除算するとSelectV2が生成され、量子化係数が異常になる問題を修正
- 入力のlabelがint64なため、concatが正常に動作しない問題を修正
- geluにint8のannotationを追加