### PR TITLE
Implement attention mask to mask decoder

### DIFF
--- a/export_video_predictor.py
+++ b/export_video_predictor.py
@@ -111,7 +111,7 @@ ann_obj_id = 1  # give a unique id to each object we interact with (it can be an
 # Let's add a 2nd positive click at (x, y) = (250, 220) to refine the mask
 # sending all clicks (and their labels) to `add_new_points_or_box`
 # for labels, `1` means positive click and `0` means negative click
-if True:#args.framework == "tflite" or args.framework == "ailia_tflite":
+if False:#args.framework == "tflite" or args.framework == "ailia_tflite":
     points = np.array([[210, 350]], dtype=np.float32)
     labels = np.array([1], np.int32)
 else:

--- a/sam2/modeling/sam/mask_decoder.py
+++ b/sam2/modeling/sam/mask_decoder.py
@@ -116,8 +116,9 @@ class MaskDecoder(nn.Module):
         dense_prompt_embeddings: torch.Tensor,
         multimask_output: bool,
         repeat_image: bool,
-        high_res_features1: Optional[torch.Tensor] = None,
-        high_res_features2: Optional[torch.Tensor] = None,
+        high_res_features1: Optional[torch.Tensor],
+        high_res_features2: Optional[torch.Tensor],
+        attn_masks: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Predict masks given image and prompt embeddings.
@@ -143,6 +144,7 @@ class MaskDecoder(nn.Module):
             repeat_image=repeat_image,
             high_res_features1=high_res_features1,
             high_res_features2=high_res_features2,
+            attn_masks=attn_masks
         )
 
         # Select the correct mask or masks for output
@@ -176,8 +178,9 @@ class MaskDecoder(nn.Module):
         sparse_prompt_embeddings: torch.Tensor,
         dense_prompt_embeddings: torch.Tensor,
         repeat_image: bool,
-        high_res_features1: Optional[torch.Tensor] = None,
-        high_res_features2: Optional[torch.Tensor] = None,
+        high_res_features1: Optional[torch.Tensor],
+        high_res_features2: Optional[torch.Tensor],
+        attn_masks: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         masks, iou_pred, mask_tokens_out, object_score_logits = self.predict_masks(
             image_embeddings=image_embeddings,
@@ -187,6 +190,7 @@ class MaskDecoder(nn.Module):
             repeat_image=repeat_image,
             high_res_features1=high_res_features1,
             high_res_features2=high_res_features2,
+            attn_masks=attn_masks
         )
         return masks, iou_pred, mask_tokens_out, object_score_logits
 
@@ -228,8 +232,9 @@ class MaskDecoder(nn.Module):
         sparse_prompt_embeddings: torch.Tensor,
         dense_prompt_embeddings: torch.Tensor,
         repeat_image: bool,
-        high_res_features1: Optional[torch.Tensor] = None,
-        high_res_features2: Optional[torch.Tensor] = None,
+        high_res_features1: Optional[torch.Tensor],
+        high_res_features2: Optional[torch.Tensor],
+        attn_masks: torch.Tensor, # for sparse_prompt_embeddings
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Predicts masks. See 'forward' for more details."""
         # Concatenate output tokens
@@ -251,8 +256,10 @@ class MaskDecoder(nn.Module):
         output_tokens = output_tokens.unsqueeze(0).expand(
             sparse_prompt_embeddings.shape[0], -1, -1
         )
+        output_tokens_attn_masks = torch.ones((output_tokens.shape[0], output_tokens.shape[1]), dtype=torch.bool)
         tokens = torch.cat((output_tokens, sparse_prompt_embeddings), dim=1)
-
+        tokens_attn_masks = torch.concat((output_tokens_attn_masks, attn_masks), dim = 1)
+        
         # Expand per-image data in batch direction to be per-mask
         if repeat_image:
             src = torch.repeat_interleave(image_embeddings, tokens.shape[0], dim=0)
@@ -272,7 +279,7 @@ class MaskDecoder(nn.Module):
         b, c, h, w = src.shape
 
         # Run the transformer
-        hs, src = self.transformer(src, pos_src, tokens)
+        hs, src = self.transformer(src, pos_src, tokens, tokens_attn_masks)
         iou_token_out = hs[:, s, :]
         mask_tokens_out = hs[:, s + 1 : (s + 1 + self.num_mask_tokens), :]
 

--- a/sam2/modeling/sam/transformer.py
+++ b/sam2/modeling/sam/transformer.py
@@ -132,7 +132,7 @@ class TwoWayTransformer(nn.Module):
         # Apply the final attention layer from the points to the image
         q = queries + point_embedding
         k = keys + image_pe
-        attn_out = self.final_attn_token_to_image.cross_attn(q=q, k=k, v=keys)
+        attn_out = self.final_attn_token_to_image.forward_without_attn_mask(q=q, k=k, v=keys)
         queries = queries + attn_out
         queries = self.norm_final_attn(queries)
 
@@ -188,10 +188,10 @@ class TwoWayAttentionBlock(nn.Module):
     ) -> Tuple[Tensor, Tensor]:
         # Self attention block
         if self.skip_first_layer_pe:
-            queries = self.self_attn.self_attn(q=queries, k=queries, v=queries, attn_mask=attn_mask)
+            queries = self.self_attn.forward_with_attn_mask(q=queries, k=queries, v=queries, attn_mask=attn_mask)
         else:
             q = queries + query_pe
-            attn_out = self.self_attn.self_attn(q=q, k=q, v=queries, attn_mask=attn_mask)
+            attn_out = self.self_attn.forward_with_attn_mask(q=q, k=q, v=queries, attn_mask=attn_mask)
             queries = queries + attn_out
         queries = self.norm1(queries)
 
@@ -200,7 +200,7 @@ class TwoWayAttentionBlock(nn.Module):
         k = keys + key_pe
         
         #print(q.shape, m.shape)
-        attn_out = self.cross_attn_token_to_image.cross_attn(q=q, k=k, v=keys)
+        attn_out = self.cross_attn_token_to_image.forward_without_attn_mask(q=q, k=k, v=keys)
         queries = queries + attn_out
         queries = self.norm2(queries)
 
@@ -212,7 +212,7 @@ class TwoWayAttentionBlock(nn.Module):
         # Cross attention block, image embedding attending to tokens
         q = queries + query_pe
         k = keys + key_pe
-        attn_out = self.cross_attn_image_to_token.cross_attn(q=k, k=q, v=queries)
+        attn_out = self.cross_attn_image_to_token.forward_with_attn_mask(q=k, k=q, v=queries, attn_mask=attn_mask)
         keys = keys + attn_out
         keys = self.norm4(keys)
 
@@ -259,7 +259,7 @@ class Attention(nn.Module):
         x = x.transpose(1, 2)
         return x.reshape(b, n_tokens, n_heads * c_per_head)  # B x N_tokens x C
 
-    def self_attn(self, q: Tensor, k: Tensor, v: Tensor, attn_mask: Tensor) -> Tensor:
+    def forward_with_attn_mask(self, q: Tensor, k: Tensor, v: Tensor, attn_mask: Tensor) -> Tensor:
         # Input projections
         q = self.q_proj(q)
         k = self.k_proj(k)
@@ -293,7 +293,7 @@ class Attention(nn.Module):
 
         return out
 
-    def cross_attn(self, q: Tensor, k: Tensor, v: Tensor) -> Tensor:
+    def forward_without_attn_mask(self, q: Tensor, k: Tensor, v: Tensor) -> Tensor:
         # Input projections
         q = self.q_proj(q)
         k = self.k_proj(k)

--- a/sam2/modeling/sam/transformer.py
+++ b/sam2/modeling/sam/transformer.py
@@ -95,6 +95,7 @@ class TwoWayTransformer(nn.Module):
         image_embedding: Tensor,
         image_pe: Tensor,
         point_embedding: Tensor,
+        point_embedding_attn_mask: Tensor
     ) -> Tuple[Tensor, Tensor]:
         """
         Args:
@@ -125,12 +126,13 @@ class TwoWayTransformer(nn.Module):
                 keys=keys,
                 query_pe=point_embedding,
                 key_pe=image_pe,
+                attn_mask=point_embedding_attn_mask
             )
 
         # Apply the final attention layer from the points to the image
         q = queries + point_embedding
         k = keys + image_pe
-        attn_out = self.final_attn_token_to_image(q=q, k=k, v=keys)
+        attn_out = self.final_attn_token_to_image.cross_attn(q=q, k=k, v=keys)
         queries = queries + attn_out
         queries = self.norm_final_attn(queries)
 
@@ -182,21 +184,23 @@ class TwoWayAttentionBlock(nn.Module):
         self.skip_first_layer_pe = skip_first_layer_pe
 
     def forward(
-        self, queries: Tensor, keys: Tensor, query_pe: Tensor, key_pe: Tensor
+        self, queries: Tensor, keys: Tensor, query_pe: Tensor, key_pe: Tensor, attn_mask:Tensor
     ) -> Tuple[Tensor, Tensor]:
         # Self attention block
         if self.skip_first_layer_pe:
-            queries = self.self_attn(q=queries, k=queries, v=queries)
+            queries = self.self_attn.self_attn(q=queries, k=queries, v=queries, attn_mask=attn_mask)
         else:
             q = queries + query_pe
-            attn_out = self.self_attn(q=q, k=q, v=queries)
+            attn_out = self.self_attn.self_attn(q=q, k=q, v=queries, attn_mask=attn_mask)
             queries = queries + attn_out
         queries = self.norm1(queries)
 
         # Cross attention block, tokens attending to image embedding
         q = queries + query_pe
         k = keys + key_pe
-        attn_out = self.cross_attn_token_to_image(q=q, k=k, v=keys)
+        
+        #print(q.shape, m.shape)
+        attn_out = self.cross_attn_token_to_image.cross_attn(q=q, k=k, v=keys)
         queries = queries + attn_out
         queries = self.norm2(queries)
 
@@ -208,7 +212,7 @@ class TwoWayAttentionBlock(nn.Module):
         # Cross attention block, image embedding attending to tokens
         q = queries + query_pe
         k = keys + key_pe
-        attn_out = self.cross_attn_image_to_token(q=k, k=q, v=queries)
+        attn_out = self.cross_attn_image_to_token.cross_attn(q=k, k=q, v=queries)
         keys = keys + attn_out
         keys = self.norm4(keys)
 
@@ -255,7 +259,41 @@ class Attention(nn.Module):
         x = x.transpose(1, 2)
         return x.reshape(b, n_tokens, n_heads * c_per_head)  # B x N_tokens x C
 
-    def forward(self, q: Tensor, k: Tensor, v: Tensor) -> Tensor:
+    def self_attn(self, q: Tensor, k: Tensor, v: Tensor, attn_mask: Tensor) -> Tensor:
+        # Input projections
+        q = self.q_proj(q)
+        k = self.k_proj(k)
+        v = self.v_proj(v)
+
+        # Separate into heads
+        q = self._separate_heads(q, self.num_heads)
+        k = self._separate_heads(k, self.num_heads)
+        v = self._separate_heads(v, self.num_heads)
+
+        dropout_p = self.dropout_p if self.training else 0.0
+        # Attention
+        #try:
+        #    with sdp_kernel_context(dropout_p):
+        #        out = F.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p)
+        #except Exception as e:
+        if True:
+            # Fall back to all kernels if the Flash attention kernel fails
+            #warnings.warn(
+            #    f"Flash Attention kernel failed due to: {e}\nFalling back to all available "
+            #    f"kernels for scaled_dot_product_attention (which may have a slower speed).",
+            #    category=UserWarning,
+            #    stacklevel=2,
+            #)
+            global ALLOW_ALL_KERNELS
+            ALLOW_ALL_KERNELS = True
+            out = F.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p, attn_mask=attn_mask)
+
+        out = self._recombine_heads(out)
+        out = self.out_proj(out)
+
+        return out
+
+    def cross_attn(self, q: Tensor, k: Tensor, v: Tensor) -> Tensor:
         # Input projections
         q = self.q_proj(q)
         k = self.k_proj(k)

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -435,6 +435,20 @@ class SAM2Base(torch.nn.Module):
             mask_input_dummy = sam_mask_prompt
             masks_enable = torch.tensor([1], dtype=torch.int)
 
+        # padding
+        convert_to_static_shape = export_to_tflite or import_from_tflite or self.calibration
+        original_sparse_embedding_length = sam_point_coords.shape[1] + 1
+        max_sparse_embedding_length = 32
+
+        if convert_to_static_shape:
+            padding_length= max_sparse_embedding_length - 1
+            sam_point_coords_pad = torch.zeros(sam_point_coords.shape[0], padding_length, sam_point_coords.shape[2])
+            sam_point_labels_pad = -torch.ones(sam_point_labels.shape[0], padding_length)
+            sam_point_coords_pad[:, 0:sam_point_coords.shape[1], :] = sam_point_coords
+            sam_point_labels_pad[:, 0:sam_point_labels.shape[1]] = sam_point_labels
+            sam_point_coords = sam_point_coords_pad
+            sam_point_labels = sam_point_labels_pad
+
         if import_from_onnx:
             if self.debug:
                 print("begin prompt encoder onnx")
@@ -465,7 +479,8 @@ class SAM2Base(torch.nn.Module):
                 "dense_prompt_embeddings": dense_embeddings.numpy(),
                 #repeat_image=False,  # the image is already batched
                 "high_res_features1":high_res_features[0].numpy(),
-                "high_res_features2":high_res_features[1].numpy()})
+                "high_res_features2":high_res_features[1].numpy(),
+                "attn_masks":attn_masks.numpy()})
             masks = torch.Tensor(masks)
             iou_pred = torch.Tensor(iou_pred)
             sam_tokens_out = torch.Tensor(sam_tokens_out)
@@ -528,6 +543,20 @@ class SAM2Base(torch.nn.Module):
                 dense_embeddings = self.prompt_encoder_tflite.get_tensor(output_details[0]["index"])
                 dense_pe = self.prompt_encoder_tflite.get_tensor(output_details[2]["index"])
 
+            if convert_to_static_shape:
+                sparse_embeddings = sparse_embeddings[:, :original_sparse_embedding_length, :]
+
+            # Prepare attn_mask for mask decoder
+            if convert_to_static_shape:
+                max_num_sparse_embeddings = max_sparse_embedding_length
+                sparse_embeddings_pad = np.zeros((sparse_embeddings.shape[0], max_num_sparse_embeddings, sparse_embeddings.shape[2]))
+                sparse_embeddings_pad[:,:sparse_embeddings.shape[1],:] = sparse_embeddings
+                attn_masks = np.zeros((sparse_embeddings_pad.shape[0], sparse_embeddings_pad.shape[1]), dtype=np.bool8)
+                attn_masks[:,:sparse_embeddings.shape[1]] = True
+                sparse_embeddings = sparse_embeddings_pad
+            else:
+                attn_masks = np.ones((sparse_embeddings.shape[0], sparse_embeddings.shape[1]), dtype=np.bool8)
+
             if self.mask_decoder_tflite == None:
                 int8_id = ""
                 if tflite_int8:
@@ -560,6 +589,7 @@ class SAM2Base(torch.nn.Module):
                 self.mask_decoder_tflite.set_tensor(input_details[5]["index"], batched_mode)
                 self.mask_decoder_tflite.set_tensor(input_details[0]["index"], self.format_input_tensor(high_res_features[0].numpy(), input_details, 0))
                 self.mask_decoder_tflite.set_tensor(input_details[4]["index"], self.format_input_tensor(high_res_features[1].numpy(), input_details, 4))
+                self.mask_decoder_tflite.set_tensor(input_details[7]["index"], self.format_input_tensor(attn_masks, input_details, 7))
                 self.mask_decoder_tflite.invoke()
 
                 masks = self.get_output_tensor(self.mask_decoder_tflite, output_details, 2)
@@ -574,6 +604,7 @@ class SAM2Base(torch.nn.Module):
                 self.mask_decoder_tflite.set_tensor(input_details[5]["index"], batched_mode)
                 self.mask_decoder_tflite.set_tensor(input_details[0]["index"], high_res_features[0].numpy())
                 self.mask_decoder_tflite.set_tensor(input_details[4]["index"], high_res_features[1].numpy())
+                self.mask_decoder_tflite.set_tensor(input_details[7]["index"], attn_masks)
                 self.mask_decoder_tflite.invoke()
 
                 masks = self.mask_decoder_tflite.get_tensor(output_details[2]["index"])

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -610,6 +610,8 @@ class SAM2Base(torch.nn.Module):
                 masks_enable=masks_enable
             )
 
+            attn_masks = torch.ones((sparse_embeddings.shape[0], sparse_embeddings.shape[1]), dtype=torch.bool)
+
             (
                 low_res_multimasks,
                 ious,
@@ -624,6 +626,7 @@ class SAM2Base(torch.nn.Module):
                 repeat_image=False,  # the image is already batched
                 high_res_features1=high_res_features[0],
                 high_res_features2=high_res_features[1],
+                attn_masks=attn_masks
             )
             if self.debug:
                 print(low_res_multimasks.shape)

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -628,7 +628,7 @@ class SAM2ImagePredictor:
             padding_length= max_sparse_embedding_length - 1
             concat_points_pad = (
                 torch.zeros(concat_points[0].shape[0], padding_length, concat_points[0].shape[2]),
-                torch.zeros(concat_points[0].shape[0], padding_length)
+                -torch.ones(concat_points[0].shape[0], padding_length)
             )
             concat_points_pad[0][:, 0:concat_points[0].shape[1], :] = concat_points[0]
             concat_points_pad[1][:, 0:concat_points[1].shape[1]] = concat_points[1]

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -1098,6 +1098,19 @@ class SAM2ImagePredictor:
             low_res_masks, iou_predictions, _, _  = self.model.sam_mask_decoder.forward_postprocess(masks, iou_pred, sam_tokens_out, object_score_logits, multimask_output)
 
         if not import_from_onnx and not import_from_tflite:
+            convert_to_static_shape = True #export_to_tflite or import_from_tflite or self.calibration
+            if convert_to_static_shape:
+                max_num_sparse_embeddings = 32 #sparse_embeddings.shape[1]
+                sparse_embeddings_pad = torch.zeros(sparse_embeddings.shape[0], max_num_sparse_embeddings, sparse_embeddings.shape[2])
+                sparse_embeddings_pad[:,:sparse_embeddings.shape[1],:] = sparse_embeddings
+                attn_masks = torch.zeros((sparse_embeddings_pad.shape[0], sparse_embeddings_pad.shape[1]), dtype=torch.bool)
+                attn_masks[:,:sparse_embeddings.shape[1]] = True
+                print(sparse_embeddings.shape)
+                print(attn_masks)
+                sparse_embeddings = sparse_embeddings_pad
+            else:
+                attn_masks = torch.ones((sparse_embeddings.shape[0], sparse_embeddings.shape[1]), dtype=torch.bool)
+
             self.model.sam_mask_decoder.forward = self.model.sam_mask_decoder.forward_normal
             low_res_masks, iou_predictions, _, _  = self.model.sam_mask_decoder(
                 image_embeddings=self._features["image_embed"][img_idx].unsqueeze(0),
@@ -1108,6 +1121,7 @@ class SAM2ImagePredictor:
                 repeat_image=batched_mode,
                 high_res_features1=high_res_features[0],
                 high_res_features2=high_res_features[1],
+                attn_masks=attn_masks
             )
 
             if self.calibration:

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -606,8 +606,9 @@ class SAM2ImagePredictor:
             concat_points = None
 
         # Convert to static shape using attn_masks
-        convert_to_static_shape = True #export_to_tflite or import_from_tflite or self.calibration
+        convert_to_static_shape = export_to_tflite or import_from_tflite or self.calibration
         original_sparse_embedding_length = concat_points[0].shape[1] + 1
+        max_sparse_embedding_length = 32
 
         # Embed prompts
         if boxes is not None:
@@ -624,7 +625,7 @@ class SAM2ImagePredictor:
                 concat_points = (box_coords, box_labels)
 
         if convert_to_static_shape:
-            padding_length= 16
+            padding_length= max_sparse_embedding_length - 1
             concat_points_pad = (
                 torch.zeros(concat_points[0].shape[0], padding_length, concat_points[0].shape[2]),
                 torch.zeros(concat_points[0].shape[0], padding_length)
@@ -875,6 +876,17 @@ class SAM2ImagePredictor:
         if convert_to_static_shape:
             sparse_embeddings = sparse_embeddings[:, :original_sparse_embedding_length, :]
 
+        # Prepare attn_mask for mask decoder
+        if convert_to_static_shape:
+            max_num_sparse_embeddings = max_sparse_embedding_length
+            sparse_embeddings_pad = torch.zeros(sparse_embeddings.shape[0], max_num_sparse_embeddings, sparse_embeddings.shape[2])
+            sparse_embeddings_pad[:,:sparse_embeddings.shape[1],:] = sparse_embeddings
+            attn_masks = torch.zeros((sparse_embeddings_pad.shape[0], sparse_embeddings_pad.shape[1]), dtype=torch.bool)
+            attn_masks[:,:sparse_embeddings.shape[1]] = True
+            sparse_embeddings = sparse_embeddings_pad
+        else:
+            attn_masks = torch.ones((sparse_embeddings.shape[0], sparse_embeddings.shape[1]), dtype=torch.bool)
+
         # Predict masks
         batched_mode = (
             concat_points is not None and concat_points[0].shape[0] > 1
@@ -890,12 +902,13 @@ class SAM2ImagePredictor:
         if export_to_onnx:
             self.model.sam_mask_decoder.forward = self.model.sam_mask_decoder.forward_masks # multimask_outputが定数になってしまうので分離
             torch.onnx.export(
-                self.model.sam_mask_decoder, (self._features["image_embed"][img_idx].unsqueeze(0), dense_pe, sparse_embeddings, dense_embeddings, batched_mode, high_res_features[0], high_res_features[1]),
+                self.model.sam_mask_decoder, (self._features["image_embed"][img_idx].unsqueeze(0), dense_pe, sparse_embeddings, dense_embeddings, batched_mode, high_res_features[0], high_res_features[1], attn_masks),
                 'model/mask_decoder_'+model_id+'.onnx',
-                input_names=["image_embeddings", "image_pe", "sparse_prompt_embeddings", "dense_prompt_embeddings", "repeat_image", "high_res_features1", "high_res_features2"],
+                input_names=["image_embeddings", "image_pe", "sparse_prompt_embeddings", "dense_prompt_embeddings", "repeat_image", "high_res_features1", "high_res_features2", "attn_masks"],
                 output_names=["masks", "iou_pred", "sam_tokens_out", "object_score_logits"],
                 dynamic_axes={
                     'sparse_prompt_embeddings': {1: 'n'},
+                    'attn_masks': {1: 'n'},
                 },
                 verbose=False, opset_version=17
             )
@@ -909,7 +922,8 @@ class SAM2ImagePredictor:
                 "sparse_prompt_embeddings": sparse_embeddings.numpy(),
                 "dense_prompt_embeddings": dense_embeddings.numpy(),
                 "high_res_features1":high_res_features[0].numpy(),
-                "high_res_features2":high_res_features[1].numpy()})
+                "high_res_features2":high_res_features[1].numpy(),
+                "attn_masks": attn_masks.numpy()})
             masks = torch.Tensor(masks)
             iou_pred = torch.Tensor(iou_pred)
             sam_tokens_out = torch.Tensor(sam_tokens_out)
@@ -918,7 +932,7 @@ class SAM2ImagePredictor:
 
         if export_to_tflite:
             self.model.sam_mask_decoder.forward = self.model.sam_mask_decoder.forward_masks
-            sample_inputs = (self._features["image_embed"][img_idx].unsqueeze(0), dense_pe, sparse_embeddings, dense_embeddings, batched_mode, high_res_features[0], high_res_features[1])
+            sample_inputs = (self._features["image_embed"][img_idx].unsqueeze(0), dense_pe, sparse_embeddings, dense_embeddings, batched_mode, high_res_features[0], high_res_features[1], attn_masks)
 
             if not tflite_int8:
                 import ai_edge_torch
@@ -996,7 +1010,8 @@ class SAM2ImagePredictor:
                         data4 = batched_mode
                         data5 = torch.tensor(npz["arr_4"])
                         data6 = torch.tensor(npz["arr_5"])
-                        model(data0, data1, data2, data3, data4, data5, data6)
+                        data7 = torch.tensor(npz["arr_6"])
+                        model(data0, data1, data2, data3, data4, data5, data6, data7)
 
                     model = quantize_pt2e.convert_pt2e(model, fold_quantize=False)
 
@@ -1033,8 +1048,9 @@ class SAM2ImagePredictor:
                             data5[0] = batched_mode
                             data0 = npz["arr_4"]
                             data4 = npz["arr_5"]
+                            data7 = npz["arr_6"]
 
-                            yield [data0, data1, data2, data3, data4, data5, data6]
+                            yield [data0, data1, data2, data3, data4, data5, data6, data7]
                     
                     tfl_converter_flags = {
                         'optimizations': [tf.lite.Optimize.DEFAULT],
@@ -1067,10 +1083,6 @@ class SAM2ImagePredictor:
                     self.mask_decoder_tflite  = tf.lite.Interpreter(model_path="model/mask_decoder_"+model_id+int8_id+".tflite")
                 self.mask_decoder_tflite.allocate_tensors()
                 input_details = self.mask_decoder_tflite.get_input_details()
-                #self.mask_decoder_tflite.resize_tensor_input(
-                #    input_details[1]["index"], 
-                #    [1, sparse_embeddings.shape[1], 256]
-                #)
                 self.mask_decoder_tflite.allocate_tensors()
 
             input_details = self.mask_decoder_tflite.get_input_details()
@@ -1086,6 +1098,7 @@ class SAM2ImagePredictor:
                 self.mask_decoder_tflite.set_tensor(input_details[5]["index"], batched_mode)
                 self.mask_decoder_tflite.set_tensor(input_details[0]["index"], self.format_input_tensor(high_res_features[0].numpy(), input_details, 0))
                 self.mask_decoder_tflite.set_tensor(input_details[4]["index"], self.format_input_tensor(high_res_features[1].numpy(), input_details, 4))
+                self.mask_decoder_tflite.set_tensor(input_details[7]["index"], self.format_input_tensor(attn_masks.numpy(), input_details, 7))
                 self.mask_decoder_tflite.invoke()
 
                 masks = self.get_output_tensor(self.mask_decoder_tflite, output_details, 2)
@@ -1100,6 +1113,7 @@ class SAM2ImagePredictor:
                 self.mask_decoder_tflite.set_tensor(input_details[5]["index"], batched_mode)
                 self.mask_decoder_tflite.set_tensor(input_details[0]["index"], high_res_features[0].numpy())
                 self.mask_decoder_tflite.set_tensor(input_details[4]["index"], high_res_features[1].numpy())
+                self.mask_decoder_tflite.set_tensor(input_details[7]["index"], attn_masks.numpy())
                 self.mask_decoder_tflite.invoke()
 
                 masks = self.mask_decoder_tflite.get_tensor(output_details[2]["index"])
@@ -1115,16 +1129,6 @@ class SAM2ImagePredictor:
             low_res_masks, iou_predictions, _, _  = self.model.sam_mask_decoder.forward_postprocess(masks, iou_pred, sam_tokens_out, object_score_logits, multimask_output)
 
         if not import_from_onnx and not import_from_tflite:
-            if convert_to_static_shape:
-                max_num_sparse_embeddings = 32 #sparse_embeddings.shape[1]
-                sparse_embeddings_pad = torch.zeros(sparse_embeddings.shape[0], max_num_sparse_embeddings, sparse_embeddings.shape[2])
-                sparse_embeddings_pad[:,:sparse_embeddings.shape[1],:] = sparse_embeddings
-                attn_masks = torch.zeros((sparse_embeddings_pad.shape[0], sparse_embeddings_pad.shape[1]), dtype=torch.bool)
-                attn_masks[:,:sparse_embeddings.shape[1]] = True
-                sparse_embeddings = sparse_embeddings_pad
-            else:
-                attn_masks = torch.ones((sparse_embeddings.shape[0], sparse_embeddings.shape[1]), dtype=torch.bool)
-
             self.model.sam_mask_decoder.forward = self.model.sam_mask_decoder.forward_normal
             low_res_masks, iou_predictions, _, _  = self.model.sam_mask_decoder(
                 image_embeddings=self._features["image_embed"][img_idx].unsqueeze(0),
@@ -1147,7 +1151,8 @@ class SAM2ImagePredictor:
                     sparse_embeddings.numpy(),
                     dense_embeddings.numpy(),
                     high_res_features[0].numpy(),
-                    high_res_features[1].numpy()
+                    high_res_features[1].numpy(),
+                    attn_masks.numpy()
                 )
                 self.calibration_cnt_mask_decoder = self.calibration_cnt_mask_decoder + 1
 

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -1105,8 +1105,6 @@ class SAM2ImagePredictor:
                 sparse_embeddings_pad[:,:sparse_embeddings.shape[1],:] = sparse_embeddings
                 attn_masks = torch.zeros((sparse_embeddings_pad.shape[0], sparse_embeddings_pad.shape[1]), dtype=torch.bool)
                 attn_masks[:,:sparse_embeddings.shape[1]] = True
-                print(sparse_embeddings.shape)
-                print(attn_masks)
                 sparse_embeddings = sparse_embeddings_pad
             else:
                 attn_masks = torch.ones((sparse_embeddings.shape[0], sparse_embeddings.shape[1]), dtype=torch.bool)

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -605,6 +605,10 @@ class SAM2ImagePredictor:
         else:
             concat_points = None
 
+        # Convert to static shape using attn_masks
+        convert_to_static_shape = True #export_to_tflite or import_from_tflite or self.calibration
+        original_sparse_embedding_length = concat_points[0].shape[1] + 1
+
         # Embed prompts
         if boxes is not None:
             box_coords = boxes.reshape(-1, 2, 2)
@@ -618,6 +622,16 @@ class SAM2ImagePredictor:
                 concat_points = (concat_coords, concat_labels)
             else:
                 concat_points = (box_coords, box_labels)
+
+        if convert_to_static_shape:
+            padding_length= 16
+            concat_points_pad = (
+                torch.zeros(concat_points[0].shape[0], padding_length, concat_points[0].shape[2]),
+                torch.zeros(concat_points[0].shape[0], padding_length)
+            )
+            concat_points_pad[0][:, 0:concat_points[0].shape[1], :] = concat_points[0]
+            concat_points_pad[1][:, 0:concat_points[1].shape[1]] = concat_points[1]
+            concat_points = concat_points_pad
 
         # New data for onnx
         if concat_points is None:
@@ -857,6 +871,9 @@ class SAM2ImagePredictor:
                     masks_enable.numpy()
                 )
                 self.calibration_cnt_prompt_encoder = self.calibration_cnt_prompt_encoder + 1
+
+        if convert_to_static_shape:
+            sparse_embeddings = sparse_embeddings[:, :original_sparse_embedding_length, :]
 
         # Predict masks
         batched_mode = (
@@ -1098,7 +1115,6 @@ class SAM2ImagePredictor:
             low_res_masks, iou_predictions, _, _  = self.model.sam_mask_decoder.forward_postprocess(masks, iou_pred, sam_tokens_out, object_score_logits, multimask_output)
 
         if not import_from_onnx and not import_from_tflite:
-            convert_to_static_shape = True #export_to_tflite or import_from_tflite or self.calibration
             if convert_to_static_shape:
                 max_num_sparse_embeddings = 32 #sparse_embeddings.shape[1]
                 sparse_embeddings_pad = torch.zeros(sparse_embeddings.shape[0], max_num_sparse_embeddings, sparse_embeddings.shape[2])


### PR DESCRIPTION
- tfliteの固定長に対応するためにmask decoderにattn maskを供給します
- dense_embeddingは固定、sparse_embeddingは可変であるため、sparse_embeddingに対してattn maskを適用します
- attn maskはattentionのkeyに対して適用されるため、self attentionと、一部のcross attentionに影響します
- prompt encoderは要素間の演算がないため、paddingしてエクスポートし、出力をカットします