### PR TITLE
SAM2.1 : Fix mask prompt encoder and apply_rotary_matenc for dynamic batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/*
 _C.*
 outputs/*
 checkpoints/*.pt
+model/
+onnx2prototxt.py

--- a/export_pe_ma.py
+++ b/export_pe_ma.py
@@ -100,10 +100,8 @@ if args.component in ("both", "memory_attention"):
         image_size=image_size,
     )
 
-    # SAM2.1 has attention_mask parameters
-    has_attention_mask = 'attention_mask_1' in [
-        p.name for p in __import__('inspect').signature(predictor.memory_attention.forward).parameters.values()
-    ]
+    # SAM2.1 has attention_mask parameters, SAM2 does not
+    has_attention_mask = (version == "2.1")
 
     if has_attention_mask:
         attention_mask_1 = torch.ones(n_1, B, dtype=torch.bool)
@@ -124,8 +122,11 @@ if args.component in ("both", "memory_attention"):
         # SAM2.1 uses .onnx extension (not .opt.onnx)
         output_path = f'model/memory_attention_{model_id}.onnx'
     else:
-        export_args = (curr, memory_1, memory_2, curr_pos, memory_pos_1, memory_pos_2)
-        input_names = ["curr", "memory_1", "memory_2", "curr_pos", "memory_pos_1", "memory_pos_2"]
+        # SAM2: pass dummy all-True attention masks as constants (not as dynamic inputs)
+        attention_mask_1 = torch.ones(n_1, B, dtype=torch.bool)
+        attention_mask_2 = torch.ones(n_2, B, dtype=torch.bool)
+        export_args = (curr, memory_1, memory_2, curr_pos, memory_pos_1, memory_pos_2, attention_mask_1, attention_mask_2)
+        input_names = ["curr", "memory_1", "memory_2", "curr_pos", "memory_pos_1", "memory_pos_2", "attention_mask_1", "attention_mask_2"]
         dynamic_axes = {
             'curr': {1: 'b'},
             'memory_1': {0: 'n_1', 1: 'b'},
@@ -133,6 +134,8 @@ if args.component in ("both", "memory_attention"):
             'curr_pos': {1: 'b'},
             'memory_pos_1': {0: 'n_1', 1: 'b'},
             'memory_pos_2': {0: 'n_2', 1: 'b'},
+            'attention_mask_1': {0: 'n_1', 1: 'b'},
+            'attention_mask_2': {0: 'n_2', 1: 'b'},
             'pix_feat': {1: 'b'}
         }
         output_path = f'model/memory_attention_{model_id}.opt.onnx'

--- a/export_pe_ma.py
+++ b/export_pe_ma.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Export prompt_encoder and memory_attention ONNX for all model sizes."""
+
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument('--model_id', default="hiera_t", choices=["hiera_l", "hiera_b+", "hiera_s", "hiera_t"])
+parser.add_argument('--component', default="both", choices=["both", "prompt_encoder", "memory_attention"])
+parser.add_argument('--image_size', default=1024, type=int, choices=[512, 1024])
+parser.add_argument('--version', default="2.1", choices=["2", "2.1"])
+args = parser.parse_args()
+
+import os
+import numpy as np
+import torch
+
+os.makedirs("model", exist_ok=True)
+
+model_id = args.model_id
+version = args.version
+if model_id == "hiera_l":
+    sam2_checkpoint = f"./checkpoints/sam{version}_hiera_large.pt"
+    model_cfg = f"configs/sam{version}/sam{version}_hiera_l.yaml"
+elif model_id == "hiera_b+":
+    sam2_checkpoint = f"./checkpoints/sam{version}_hiera_base_plus.pt"
+    model_cfg = f"configs/sam{version}/sam{version}_hiera_b+.yaml"
+elif model_id == "hiera_s":
+    sam2_checkpoint = f"./checkpoints/sam{version}_hiera_small.pt"
+    model_cfg = f"configs/sam{version}/sam{version}_hiera_s.yaml"
+elif model_id == "hiera_t":
+    sam2_checkpoint = f"./checkpoints/sam{version}_hiera_tiny.pt"
+    model_cfg = f"configs/sam{version}/sam{version}_hiera_t.yaml"
+
+if args.image_size == 512:
+    model_id = model_id + "_512"
+
+device = torch.device("cpu")
+
+# Export prompt_encoder
+if args.component in ("both", "prompt_encoder"):
+    print(f"=== Exporting prompt_encoder for {model_id} (SAM{version}) ===")
+    from sam2.build_sam import build_sam2
+    sam2_model = build_sam2(model_cfg, sam2_checkpoint, device=device, image_size=args.image_size)
+    sam2_model.eval()
+
+    # Dummy inputs matching the export in sam2_image_predictor.py
+    coords = torch.rand(1, 2, 2, dtype=torch.float32)  # batch=1, n=2 points, xy
+    labels = torch.ones(1, 2, dtype=torch.int32)         # batch=1, n=2 labels
+    mask_input = torch.zeros(1, 1, sam2_model.image_size // 4, sam2_model.image_size // 4, dtype=torch.float32)
+    masks_enable = torch.tensor([0], dtype=torch.int32)
+
+    output_path = f'model/prompt_encoder_{model_id}.onnx'
+    torch.onnx.export(
+        sam2_model.sam_prompt_encoder,
+        (coords, labels, mask_input, masks_enable),
+        output_path,
+        input_names=["coords", "labels", "masks", "masks_enable"],
+        output_names=["sparse_embeddings", "dense_embeddings", "dense_pe"],
+        dynamic_axes={
+            'coords': {0: 'b', 1: 'n'},
+            'labels': {0: 'b', 1: 'n'},
+            'masks': {0: 'b', 1: 'c', 2: 'h', 3: 'w'},
+        },
+        verbose=False, opset_version=17
+    )
+    print(f"  Saved: {output_path}")
+    del sam2_model
+    torch.cuda.empty_cache() if torch.cuda.is_available() else None
+    import gc; gc.collect()
+
+# Export memory_attention
+if args.component in ("both", "memory_attention"):
+    print(f"=== Exporting memory_attention for {model_id} (SAM{version}) ===")
+    from sam2.build_sam import build_sam2_video_predictor
+    predictor = build_sam2_video_predictor(model_cfg, sam2_checkpoint, device=device, image_size=args.image_size)
+    predictor.eval()
+
+    image_size = args.image_size
+    mem_dim = predictor.mem_dim  # typically 64
+    hidden_dim = predictor.hidden_dim  # typically 256
+
+    # Dummy inputs matching the shapes from sam2_base.py memory attention export
+    seq_len = (image_size // 16) ** 2
+    B = 1
+    curr = torch.randn(seq_len, B, hidden_dim, dtype=torch.float32)
+    curr_pos = torch.randn(seq_len, B, hidden_dim, dtype=torch.float32)
+
+    # memory_1: RoPE-applied memory (n_1, batch, mem_dim)
+    # memory_2: non-RoPE memory / obj pointers (n_2, batch, mem_dim)
+    n_1 = seq_len  # one frame of memory
+    n_2 = 1  # one obj pointer token
+    memory_1 = torch.randn(n_1, B, mem_dim, dtype=torch.float32)
+    memory_2 = torch.randn(n_2, B, mem_dim, dtype=torch.float32)
+    memory_pos_1 = torch.randn(n_1, B, mem_dim, dtype=torch.float32)
+    memory_pos_2 = torch.randn(n_2, B, mem_dim, dtype=torch.float32)
+
+    # Pre-allocate RoPE weights
+    predictor.memory_attention.allocate_rope_attention_weight(
+        curr=[curr],
+        curr_pos=[curr_pos],
+        image_size=image_size,
+    )
+
+    # SAM2.1 has attention_mask parameters
+    has_attention_mask = 'attention_mask_1' in [
+        p.name for p in __import__('inspect').signature(predictor.memory_attention.forward).parameters.values()
+    ]
+
+    if has_attention_mask:
+        attention_mask_1 = torch.ones(n_1, B, dtype=torch.bool)
+        attention_mask_2 = torch.ones(n_2, B, dtype=torch.bool)
+        export_args = (curr, memory_1, memory_2, curr_pos, memory_pos_1, memory_pos_2, attention_mask_1, attention_mask_2)
+        input_names = ["curr", "memory_1", "memory_2", "curr_pos", "memory_pos_1", "memory_pos_2", "attention_mask_1", "attention_mask_2"]
+        dynamic_axes = {
+            'curr': {1: 'b'},
+            'memory_1': {0: 'n_1', 1: 'b'},
+            'memory_2': {0: 'n_2', 1: 'b'},
+            'curr_pos': {1: 'b'},
+            'memory_pos_1': {0: 'n_1', 1: 'b'},
+            'memory_pos_2': {0: 'n_2', 1: 'b'},
+            'attention_mask_1': {0: 'n_1', 1: 'b'},
+            'attention_mask_2': {0: 'n_2', 1: 'b'},
+            'pix_feat': {1: 'b'}
+        }
+        # SAM2.1 uses .onnx extension (not .opt.onnx)
+        output_path = f'model/memory_attention_{model_id}.onnx'
+    else:
+        export_args = (curr, memory_1, memory_2, curr_pos, memory_pos_1, memory_pos_2)
+        input_names = ["curr", "memory_1", "memory_2", "curr_pos", "memory_pos_1", "memory_pos_2"]
+        dynamic_axes = {
+            'curr': {1: 'b'},
+            'memory_1': {0: 'n_1', 1: 'b'},
+            'memory_2': {0: 'n_2', 1: 'b'},
+            'curr_pos': {1: 'b'},
+            'memory_pos_1': {0: 'n_1', 1: 'b'},
+            'memory_pos_2': {0: 'n_2', 1: 'b'},
+            'pix_feat': {1: 'b'}
+        }
+        output_path = f'model/memory_attention_{model_id}.opt.onnx'
+
+    torch.onnx.export(
+        predictor.memory_attention,
+        export_args,
+        output_path,
+        input_names=input_names,
+        output_names=["pix_feat"],
+        dynamic_axes=dynamic_axes,
+        verbose=False, opset_version=17
+    )
+    print(f"  Saved: {output_path}")
+
+print("Done!")

--- a/sam2/modeling/memory_attention.py
+++ b/sam2/modeling/memory_attention.py
@@ -178,8 +178,10 @@ class MemoryAttention(nn.Module):
             memory_2 = memory_2.transpose(0, 1)
             memory_pos_1 = memory_pos_1.transpose(0, 1)
             memory_pos_2 = memory_pos_2.transpose(0, 1)
-            attention_mask_1 = attention_mask_1.transpose(0, 1)
-            attention_mask_2 = attention_mask_2.transpose(0, 1)
+            if attention_mask_1 is not None:
+                attention_mask_1 = attention_mask_1.transpose(0, 1)
+            if attention_mask_2 is not None:
+                attention_mask_2 = attention_mask_2.transpose(0, 1)
 
         for layer in self.layers:
             output = layer(

--- a/sam2/modeling/position_encoding.py
+++ b/sam2/modeling/position_encoding.py
@@ -243,59 +243,51 @@ def get_rotation_matrices(dim, end_x, end_y, theta=10000.0, device=None, dtype=N
 
 
 def apply_rotary_matenc(xq, xk, rotmats, repeat_freqs_k=False):
-    # オリジナル実装 (6次元テンソル処理)
-    #bq, hq, nq, cq = xq.shape
-    #bk, hk, nk, ck = xk.shape
-    #q_out = torch.matmul(rotmats, xq.reshape(bq, hq, nq, cq // 2, 2, 1)).flatten(3)
-    #k_rotmat = rotmats.repeat(1, 1, nk // nq, 1, 1, 1) if repeat_freqs_k else rotmats
-    #k_out = torch.matmul(k_rotmat, xk.reshape(bk, hk, nk, ck // 2, 2, 1)).flatten(3)
-
-    # tfliteでは4次元テンソルまでしか扱えないのでバッチサイズに制約をかける
-
+    # 6次元テンソル処理 (バッチ次元を動的にサポート)
     bq, hq, nq, cq = xq.shape
-    #torch._check_is_size(bq)
-    #torch._check_is_size(hq)
-    #torch._check_is_size(nq)
-    #torch._check_is_size(cq)
-    #torch._check(bq == 1) # for dynamo trace
-    #torch._check(hq == 1) # for dynamo trace
-    #torch._check(cq == 256) # for dynamo trace
+    bk, hk, nk, ck = xk.shape
+    q_out = torch.matmul(rotmats, xq.reshape(bq, hq, nq, cq // 2, 2, 1)).flatten(3)
+    k_rotmat = rotmats.repeat(1, 1, nk // nq, 1, 1, 1) if repeat_freqs_k else rotmats
+    k_out = torch.matmul(k_rotmat, xk.reshape(bk, hk, nk, ck // 2, 2, 1)).flatten(3)
+    return q_out, k_out
 
-    #print(rotmats.shape)
+
+def apply_rotary_matenc_4d(xq, xk, rotmats, repeat_freqs_k=False):
+    # tfliteでは4次元テンソルまでしか扱えないのでバッチサイズに制約をかける
+    bq, hq, nq, cq = xq.shape
 
     q_rotmat = rotmats.reshape(4096, 128, 2, 2)
     q_out = torch.matmul(q_rotmat, xq.reshape(nq, 128, 2, 1)).reshape(1, 1, 4096, 256)
-    #print(q_out.shape)
 
     bk, hk, nk, ck = xk.shape
-    k_rotmat = q_rotmat.repeat(nk // 4096, 1, 1, 1)# if repeat_freqs_k else rotmats # for tflite trace, repeat_freqs_k == Falseの場合は nk // nq == 1 なのでrepeatを常に呼び出しても等価になる
+    k_rotmat = q_rotmat.repeat(nk // 4096, 1, 1, 1)
 
     bk, hk, nk, ck = xk.shape
-    #torch._check_is_size(bq == 1)
-    #torch._check_is_size(hq == 1)
-    #torch._check(ck == 256)
-
-    #torch._check(xk.size(3) == 256)
-    
     k_in = xk.reshape(nk, 128, 2, 1)
-    #k_in = k_in[:k_rotmat.shape[0], :, :, :]
     k_out = torch.matmul(k_rotmat, k_in).reshape(1, 1, nk, 256)
-
-    #print("k_rotmat", k_rotmat.shape)
-    #print("k_in", k_in.shape)
-    #print("k_out", k_out.shape)
 
     return q_out, k_out
 
 
 def apply_rotary_matenc_512(xq, xk, rotmats, repeat_freqs_k=False):
+    # 6次元テンソル処理 (バッチ次元を動的にサポート)
+    bq, hq, nq, cq = xq.shape
+    bk, hk, nk, ck = xk.shape
+    q_out = torch.matmul(rotmats, xq.reshape(bq, hq, nq, cq // 2, 2, 1)).flatten(3)
+    k_rotmat = rotmats.repeat(1, 1, nk // nq, 1, 1, 1) if repeat_freqs_k else rotmats
+    k_out = torch.matmul(k_rotmat, xk.reshape(bk, hk, nk, ck // 2, 2, 1)).flatten(3)
+    return q_out, k_out
+
+
+def apply_rotary_matenc_512_4d(xq, xk, rotmats, repeat_freqs_k=False):
+    # tfliteでは4次元テンソルまでしか扱えないのでバッチサイズに制約をかける
     bq, hq, nq, cq = xq.shape
     q_rotmat = rotmats.reshape(1024, 128, 2, 2)
     q_out = torch.matmul(q_rotmat, xq.reshape(nq, 128, 2, 1)).reshape(1, 1, 1024, 256)
 
     bk, hk, nk, ck = xk.shape
     k_rotmat = q_rotmat.repeat(nk // 1024, 1, 1, 1)
-    
+
     bk, hk, nk, ck = xk.shape
     k_in = xk.reshape(nk, 128, 2, 1)
     k_out = torch.matmul(k_rotmat, k_in).reshape(1, 1, nk, 256)

--- a/sam2/modeling/sam/transformer.py
+++ b/sam2/modeling/sam/transformer.py
@@ -15,7 +15,7 @@ import torch.nn.functional as F
 from torch import nn, Tensor
 
 from sam2.modeling.position_encoding import apply_rotary_enc, compute_axial_cis
-from sam2.modeling.position_encoding import apply_rotary_matenc, get_rotation_matrices, apply_rotary_matenc_512
+from sam2.modeling.position_encoding import apply_rotary_matenc, get_rotation_matrices, apply_rotary_matenc_512, apply_rotary_matenc_4d, apply_rotary_matenc_512_4d
 from sam2.modeling.sam2_utils import MLP
 from sam2.utils.misc import get_sdpa_settings
 

--- a/sam2/modeling/sam2_base.py
+++ b/sam2/modeling/sam2_base.py
@@ -419,7 +419,7 @@ class SAM2Base(torch.nn.Module):
 
         if sam_mask_prompt is None:
             import numpy as np
-            mask_input_dummy = torch.Tensor(np.zeros((1, self.image_size // 4, self.image_size // 4)))
+            mask_input_dummy = torch.Tensor(np.zeros((1, 1, self.image_size // 4, self.image_size // 4)))
             masks_enable = torch.tensor([0], dtype=torch.int)
         else:
             mask_input_dummy = sam_mask_prompt
@@ -547,7 +547,7 @@ class SAM2Base(torch.nn.Module):
                 print("backbone_features", backbone_features.shape)
             if sam_mask_prompt is None:
                 import numpy as np
-                mask_input_dummy = torch.Tensor(np.zeros((1, self.image_size // 4, self.image_size // 4)))
+                mask_input_dummy = torch.Tensor(np.zeros((1, 1, self.image_size // 4, self.image_size // 4)))
                 masks_enable = torch.tensor([0], dtype=torch.int)
             else:
                 mask_input_dummy = sam_mask_prompt
@@ -1075,12 +1075,15 @@ class SAM2Base(torch.nn.Module):
                 input_names=["curr", "memory_1", "memory_2", "curr_pos", "memory_pos_1", "memory_pos_2", "attention_mask_1", "attention_mask_2"],
                 output_names=["pix_feat"],
                 dynamic_axes={
-                    'memory_1': {0: 'n_1'},
-                    'memory_2': {0: 'n_2'},
-                    'memory_pos_1': {0: 'n_1'},
-                    'memory_pos_2': {0: 'n_2'},
-                    'attention_mask_1': {0: 'n_1'},
-                    'attention_mask_2': {0: 'n_2'}
+                    'curr': {1: 'b'},
+                    'memory_1': {0: 'n_1', 1: 'b'},
+                    'memory_2': {0: 'n_2', 1: 'b'},
+                    'curr_pos': {1: 'b'},
+                    'memory_pos_1': {0: 'n_1', 1: 'b'},
+                    'memory_pos_2': {0: 'n_2', 1: 'b'},
+                    'attention_mask_1': {0: 'n_1', 1: 'b'},
+                    'attention_mask_2': {0: 'n_2', 1: 'b'},
+                    'pix_feat': {1: 'b'}
                 },
                 verbose=False, opset_version=17
             )

--- a/sam2/sam2_image_predictor.py
+++ b/sam2/sam2_image_predictor.py
@@ -535,7 +535,7 @@ class SAM2ImagePredictor:
         if concat_points is None:
             raise ("concat points must be exists") # Noneの場合はtensorサイズが0のテンソルを返さないといけないためwhereで組めない
         if mask_input is None:
-            mask_input_dummy = torch.Tensor(np.zeros((1, self.model.image_size // 4, self.model.image_size // 4)))
+            mask_input_dummy = torch.Tensor(np.zeros((1, 1, self.model.image_size // 4, self.model.image_size // 4)))
             masks_enable = torch.tensor([0], dtype=torch.int) # boolだとonnxへのエクスポートのwhereでエラーになる
         else:
             mask_input_dummy = mask_input
@@ -551,7 +551,7 @@ class SAM2ImagePredictor:
                 dynamic_axes={
                     'coords': {0: 'b', 1: 'n'},
                     'labels': {0: 'b', 1: 'n'},
-                    'masks': {0: 'b', 1: 'h', 2: 'w'},
+                    'masks': {0: 'b', 1: 'c', 2: 'h', 3: 'w'},
                 },
                 verbose=False, opset_version=17
             )


### PR DESCRIPTION
概要
- prompt_encoder: マスク入力を3D→4D (Conv2d対応) で再エクスポート、dynamic_axesも masks: {0:'b', 1:'c', 2:'h', 3:'w'} に修正
- memory_attention: apply_rotary_matenc を6D matmul (動的バッチサポート) で再エクスポート、dynamic_axesにバッチ次元追加

#14 のSAM2.1版。